### PR TITLE
Fixed Jira issue 6.3.0-SNAPSHOT build error. setOrganization... no longe...

### DIFF
--- a/kie-wb-smoke-tests/src/test/java/org/kie/smoke/wb/rest/GuvnorRestSmokeIntegrationTest.java
+++ b/kie-wb-smoke-tests/src/test/java/org/kie/smoke/wb/rest/GuvnorRestSmokeIntegrationTest.java
@@ -150,7 +150,7 @@ public class GuvnorRestSmokeIntegrationTest extends AbstractWorkbenchIntegration
             newRepo.setName(repoName);
             newRepo.setDescription("repo for rest services smoke tests");
             newRepo.setRequestType("new");
-            newRepo.setOrganizationalUnitName(orgUnitName);
+            //newRepo.setOrganizationalUnitName(orgUnitName);
             addToRequestBody(restRequest, newRepo);
 
             CreateOrCloneRepositoryRequest createJobRequest = post(restRequest, mediaType, 202, CreateOrCloneRepositoryRequest.class);
@@ -367,7 +367,7 @@ public class GuvnorRestSmokeIntegrationTest extends AbstractWorkbenchIntegration
             newRepo.setName(repoName);
             newRepo.setDescription("repo for testing rest services");
             newRepo.setRequestType("new");
-            newRepo.setOrganizationalUnitName(ouList.get(0).getName());
+            //newRepo.setOrganizationalUnitName(ouList.get(0).getName());
             addToRequestBody(restRequest, newRepo);
 
             CreateOrCloneRepositoryRequest createRepoRequest = post(restRequest, mediaType, 202, CreateOrCloneRepositoryRequest.class);

--- a/kie-wb-smoke-tests/src/test/java/org/kie/smoke/wb/util/RestRepositoryDeploymentUtil.java
+++ b/kie-wb-smoke-tests/src/test/java/org/kie/smoke/wb/util/RestRepositoryDeploymentUtil.java
@@ -107,7 +107,7 @@ public class RestRepositoryDeploymentUtil {
         repoRequest.setName(repositoryName);
         repoRequest.setRequestType("clone");
         repoRequest.setGitURL(cloneRepoUrl);
-        repoRequest.setOrganizationalUnitName(orgUnit);
+        //repoRequest.setOrganizationalUnitName(orgUnit);
         String input = serializeToJsonString(repoRequest);
         ClientRequest request = createRequest("repositories/", input);
         return post( request, mediaType, 202, CreateOrCloneRepositoryRequest.class);


### PR DESCRIPTION
...r a method of RepoRequest

kie-wb-distributions/kie-wb-smoke-tests/src/test/java/org/kie/smoke/wb/rest/GuvnorRestSmokeIntegrationTest.java was referencing RepoRequest.setOrganization... which is no longer a method of RepoRequest.  I commented out the 2 lines involved.  This has been more fully fixed in the master version, but it was stopping 6.3.0-SNAPSHOT from building.

kie-wb-distributions/kie-wb-smoke-tests/src/test/java/org/kie/smoke/wb/util/RestRepositoryDeploymentUtil.java also had the same issue.
