### PR TITLE
Move dependency versions to depMgmt and re-enable enforcer

### DIFF
--- a/kie-drools-wb/kie-drools-wb-distribution-wars-cdi1.0/pom.xml
+++ b/kie-drools-wb/kie-drools-wb-distribution-wars-cdi1.0/pom.xml
@@ -15,6 +15,23 @@
   <name>KIE Drools Workbench - Distribution Wars for CDI 1.0</name>
   <description>This module builds the download wars for different application servers.</description>
 
+  <dependencyManagement>
+    <dependencies>
+      <!-- Errai integration that supports CDI 1.0 -->
+      <dependency>
+        <groupId>org.jboss.errai</groupId>
+        <artifactId>errai-weld-integration</artifactId>
+        <version>${version.org.jboss.errai.errai-weld-integration-cdi10}</version>
+      </dependency>
+      <!-- TODO: move the following artifact to kie-parent-with-dependencies -->
+      <dependency>
+        <groupId>net.jcip</groupId>
+        <artifactId>jcip-annotations</artifactId>
+        <version>1.0</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <!-- Internal dependencies -->
     <dependency>
@@ -143,7 +160,6 @@
     <dependency>
       <groupId>net.jcip</groupId>
       <artifactId>jcip-annotations</artifactId>
-      <version>1.0</version>
     </dependency>
 
     <dependency>
@@ -348,7 +364,6 @@
     <dependency>
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-weld-integration</artifactId>
-      <version>3.0.4.Final</version>
     </dependency>
   </dependencies>
 
@@ -409,16 +424,6 @@
             <addMavenDescriptor>false</addMavenDescriptor>
           </archive>
         </configuration>
-      </plugin>
-      <!-- disable enforcer -->
-      <plugin>
-        <artifactId>maven-enforcer-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>no-managed-deps</id>
-            <phase>none</phase>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>

--- a/kie-wb/kie-wb-distribution-wars-cdi1.0/pom.xml
+++ b/kie-wb/kie-wb-distribution-wars-cdi1.0/pom.xml
@@ -15,6 +15,23 @@
   <name>KIE Workbench - Distribution Wars for CDI 1.0</name>
   <description>This module builds the download wars for different application servers.</description>
 
+  <dependencyManagement>
+    <dependencies>
+      <!-- Errai integration that supports CDI 1.0 -->
+      <dependency>
+        <groupId>org.jboss.errai</groupId>
+        <artifactId>errai-weld-integration</artifactId>
+        <version>${version.org.jboss.errai.errai-weld-integration-cdi10}</version>
+      </dependency>
+      <!-- TODO: move the following artifact to kie-parent-with-dependencies -->
+      <dependency>
+        <groupId>net.jcip</groupId>
+        <artifactId>jcip-annotations</artifactId>
+        <version>1.0</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <!-- Internal dependencies -->
     <dependency>
@@ -143,7 +160,6 @@
     <dependency>
       <groupId>net.jcip</groupId>
       <artifactId>jcip-annotations</artifactId>
-      <version>1.0</version>
     </dependency>
 
     <dependency>
@@ -348,7 +364,6 @@
     <dependency>
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-weld-integration</artifactId>
-      <version>3.0.4.Final</version>
     </dependency>
   </dependencies>
 
@@ -413,16 +428,6 @@
             </manifestEntries>
           </archive>
         </configuration>
-      </plugin>
-      <!-- disable enforcer -->
-      <plugin>
-        <artifactId>maven-enforcer-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>no-managed-deps</id>
-            <phase>none</phase>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,11 @@
   <name>KIE Workbench - Distributions</name>
   <description>KIE Workbench - Distributions</description>
 
+  <properties>
+    <!-- Errai Weld integration that supports CDI 1.0 -->
+    <version.org.jboss.errai.errai-weld-integration-cdi10>3.0.4.Final</version.org.jboss.errai.errai-weld-integration-cdi10>
+  </properties>
+
   <repositories>
     <!-- Bootstrap repository to locate the parent pom when the parent pom has not been build locally. -->
     <repository>


### PR DESCRIPTION
@porcelli This way we can use different version for `errai-weld-integration` and still leverage the enforcer no-managed-deps rule.