### PR TITLE
BZ-1221380: remove use of cookies (that have 4k limit) what, depending

### DIFF
--- a/kie-drools-wb/kie-drools-wb-distribution-wars-cdi1.0/src/main/assembly/tomcat7/WEB-INF/web.xml
+++ b/kie-drools-wb/kie-drools-wb-distribution-wars-cdi1.0/src/main/assembly/tomcat7/WEB-INF/web.xml
@@ -27,6 +27,16 @@
   </filter-mapping>
 
   <filter>
+    <filter-name>Host Page Patch</filter-name>
+    <filter-class>org.jboss.errai.security.server.servlet.UserHostPageFilter</filter-class>
+  </filter>
+
+  <filter-mapping>
+    <filter-name>Host Page Patch</filter-name>
+    <url-pattern>/kie-drools-wb.html</url-pattern>
+  </filter-mapping>
+
+  <filter>
     <filter-name>UberFire Security Headers Filter</filter-name>
     <filter-class>org.uberfire.ext.security.server.SecureHeadersFilter</filter-class>
     <init-param>

--- a/kie-drools-wb/kie-drools-wb-distribution-wars-cdi1.0/src/main/assembly/was8/WEB-INF/web.xml
+++ b/kie-drools-wb/kie-drools-wb-distribution-wars-cdi1.0/src/main/assembly/was8/WEB-INF/web.xml
@@ -30,6 +30,16 @@
   </filter-mapping>
 
   <filter>
+    <filter-name>Host Page Patch</filter-name>
+    <filter-class>org.jboss.errai.security.server.servlet.UserHostPageFilter</filter-class>
+  </filter>
+
+  <filter-mapping>
+    <filter-name>Host Page Patch</filter-name>
+    <url-pattern>/kie-drools-wb.html</url-pattern>
+  </filter-mapping>
+
+  <filter>
     <filter-name>UberFire Security Headers Filter</filter-name>
     <filter-class>org.uberfire.ext.security.server.SecureHeadersFilter</filter-class>
     <init-param>

--- a/kie-drools-wb/kie-drools-wb-distribution-wars-cdi1.0/src/main/assembly/weblogic12/WEB-INF/web.xml
+++ b/kie-drools-wb/kie-drools-wb-distribution-wars-cdi1.0/src/main/assembly/weblogic12/WEB-INF/web.xml
@@ -22,6 +22,16 @@
   </filter-mapping>
 
   <filter>
+    <filter-name>Host Page Patch</filter-name>
+    <filter-class>org.jboss.errai.security.server.servlet.UserHostPageFilter</filter-class>
+  </filter>
+
+  <filter-mapping>
+    <filter-name>Host Page Patch</filter-name>
+    <url-pattern>/kie-drools-wb.html</url-pattern>
+  </filter-mapping>
+
+  <filter>
     <filter-name>UberFire Security Headers Filter</filter-name>
     <filter-class>org.uberfire.ext.security.server.SecureHeadersFilter</filter-class>
     <init-param>

--- a/kie-drools-wb/kie-drools-wb-webapp/src/main/resources/ErraiApp.properties
+++ b/kie-drools-wb/kie-drools-wb-webapp/src/main/resources/ErraiApp.properties
@@ -30,4 +30,4 @@
 # file, although it is rarely necessary. See the documentation at
 # https://docs.jboss.org/author/display/ERRAI/ErraiApp.properties
 # for details.
-errai.security.user_cookie_enabled=true
+errai.security.user_on_hostpage_enabled=true

--- a/kie-drools-wb/kie-drools-wb-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/kie-drools-wb/kie-drools-wb-webapp/src/main/webapp/WEB-INF/web.xml
@@ -27,6 +27,16 @@
   </filter-mapping>
 
   <filter>
+    <filter-name>Host Page Patch</filter-name>
+    <filter-class>org.jboss.errai.security.server.servlet.UserHostPageFilter</filter-class>
+  </filter>
+
+  <filter-mapping>
+    <filter-name>Host Page Patch</filter-name>
+    <url-pattern>/kie-drools-wb.html</url-pattern>
+  </filter-mapping>
+
+  <filter>
     <filter-name>UberFire Security Headers Filter</filter-name>
     <filter-class>org.uberfire.ext.security.server.SecureHeadersFilter</filter-class>
     <init-param>

--- a/kie-wb/kie-wb-distribution-wars-cdi1.0/src/main/assembly/eap6_4/WEB-INF/web-ui-server.xml
+++ b/kie-wb/kie-wb-distribution-wars-cdi1.0/src/main/assembly/eap6_4/WEB-INF/web-ui-server.xml
@@ -21,6 +21,16 @@
   </filter-mapping>
 
   <filter>
+    <filter-name>Host Page Patch</filter-name>
+    <filter-class>org.jboss.errai.security.server.servlet.UserHostPageFilter</filter-class>
+  </filter>
+
+  <filter-mapping>
+    <filter-name>Host Page Patch</filter-name>
+    <url-pattern>/kie-wb.html</url-pattern>
+  </filter-mapping>
+
+  <filter>
     <filter-name>UberFire Security Headers Filter</filter-name>
     <filter-class>org.uberfire.ext.security.server.SecureHeadersFilter</filter-class>
     <init-param>

--- a/kie-wb/kie-wb-distribution-wars-cdi1.0/src/main/assembly/tomcat7/WEB-INF/web-ui-server.xml
+++ b/kie-wb/kie-wb-distribution-wars-cdi1.0/src/main/assembly/tomcat7/WEB-INF/web-ui-server.xml
@@ -25,6 +25,16 @@
   </filter-mapping>
 
   <filter>
+    <filter-name>Host Page Patch</filter-name>
+    <filter-class>org.jboss.errai.security.server.servlet.UserHostPageFilter</filter-class>
+  </filter>
+
+  <filter-mapping>
+    <filter-name>Host Page Patch</filter-name>
+    <url-pattern>/kie-wb.html</url-pattern>
+  </filter-mapping>
+
+  <filter>
     <filter-name>UberFire Security Headers Filter</filter-name>
     <filter-class>org.uberfire.ext.security.server.SecureHeadersFilter</filter-class>
     <init-param>

--- a/kie-wb/kie-wb-distribution-wars-cdi1.0/src/main/assembly/tomcat7/WEB-INF/web.xml
+++ b/kie-wb/kie-wb-distribution-wars-cdi1.0/src/main/assembly/tomcat7/WEB-INF/web.xml
@@ -27,6 +27,16 @@
   </filter-mapping>
 
   <filter>
+    <filter-name>Host Page Patch</filter-name>
+    <filter-class>org.jboss.errai.security.server.servlet.UserHostPageFilter</filter-class>
+  </filter>
+
+  <filter-mapping>
+    <filter-name>Host Page Patch</filter-name>
+    <url-pattern>/kie-wb.html</url-pattern>
+  </filter-mapping>
+
+  <filter>
     <filter-name>UberFire Security Headers Filter</filter-name>
     <filter-class>org.uberfire.ext.security.server.SecureHeadersFilter</filter-class>
     <init-param>

--- a/kie-wb/kie-wb-distribution-wars-cdi1.0/src/main/assembly/was8/WEB-INF/web-ui-server.xml
+++ b/kie-wb/kie-wb-distribution-wars-cdi1.0/src/main/assembly/was8/WEB-INF/web-ui-server.xml
@@ -21,6 +21,16 @@
   </filter-mapping>
 
   <filter>
+    <filter-name>Host Page Patch</filter-name>
+    <filter-class>org.jboss.errai.security.server.servlet.UserHostPageFilter</filter-class>
+  </filter>
+
+  <filter-mapping>
+    <filter-name>Host Page Patch</filter-name>
+    <url-pattern>/kie-wb.html</url-pattern>
+  </filter-mapping>
+
+  <filter>
     <filter-name>UberFire Security Headers Filter</filter-name>
     <filter-class>org.uberfire.ext.security.server.SecureHeadersFilter</filter-class>
     <init-param>

--- a/kie-wb/kie-wb-distribution-wars-cdi1.0/src/main/assembly/was8/WEB-INF/web.xml
+++ b/kie-wb/kie-wb-distribution-wars-cdi1.0/src/main/assembly/was8/WEB-INF/web.xml
@@ -29,6 +29,16 @@
   </filter-mapping>
 
   <filter>
+    <filter-name>Host Page Patch</filter-name>
+    <filter-class>org.jboss.errai.security.server.servlet.UserHostPageFilter</filter-class>
+  </filter>
+
+  <filter-mapping>
+    <filter-name>Host Page Patch</filter-name>
+    <url-pattern>/kie-wb.html</url-pattern>
+  </filter-mapping>
+
+  <filter>
     <filter-name>UberFire Security Headers Filter</filter-name>
     <filter-class>org.uberfire.ext.security.server.SecureHeadersFilter</filter-class>
     <init-param>

--- a/kie-wb/kie-wb-distribution-wars-cdi1.0/src/main/assembly/weblogic12/WEB-INF/web-ui-server.xml
+++ b/kie-wb/kie-wb-distribution-wars-cdi1.0/src/main/assembly/weblogic12/WEB-INF/web-ui-server.xml
@@ -11,6 +11,26 @@
   </listener>
 
   <filter>
+    <filter-name>request-capture</filter-name>
+    <filter-class>org.uberfire.ext.security.server.SecurityIntegrationFilter</filter-class>
+  </filter>
+
+  <filter-mapping>
+    <filter-name>request-capture</filter-name>
+    <url-pattern>/*</url-pattern>
+  </filter-mapping>
+
+  <filter>
+    <filter-name>Host Page Patch</filter-name>
+    <filter-class>org.jboss.errai.security.server.servlet.UserHostPageFilter</filter-class>
+  </filter>
+
+  <filter-mapping>
+    <filter-name>Host Page Patch</filter-name>
+    <url-pattern>/kie-wb.html</url-pattern>
+  </filter-mapping>
+
+  <filter>
     <filter-name>UberFire Security Headers Filter</filter-name>
     <filter-class>org.uberfire.ext.security.server.SecureHeadersFilter</filter-class>
     <init-param>

--- a/kie-wb/kie-wb-distribution-wars-cdi1.0/src/main/assembly/weblogic12/WEB-INF/web.xml
+++ b/kie-wb/kie-wb-distribution-wars-cdi1.0/src/main/assembly/weblogic12/WEB-INF/web.xml
@@ -19,6 +19,16 @@
   </filter-mapping>
 
   <filter>
+    <filter-name>Host Page Patch</filter-name>
+    <filter-class>org.jboss.errai.security.server.servlet.UserHostPageFilter</filter-class>
+  </filter>
+
+  <filter-mapping>
+    <filter-name>Host Page Patch</filter-name>
+    <url-pattern>/kie-wb.html</url-pattern>
+  </filter-mapping>
+
+  <filter>
     <filter-name>UberFire Security Headers Filter</filter-name>
     <filter-class>org.uberfire.ext.security.server.SecureHeadersFilter</filter-class>
     <init-param>

--- a/kie-wb/kie-wb-distribution-wars/src/main/assembly/wildfly8/WEB-INF/web-ui-server.xml
+++ b/kie-wb/kie-wb-distribution-wars/src/main/assembly/wildfly8/WEB-INF/web-ui-server.xml
@@ -12,6 +12,26 @@
   </listener>
 
   <filter>
+    <filter-name>request-capture</filter-name>
+    <filter-class>org.uberfire.ext.security.server.SecurityIntegrationFilter</filter-class>
+  </filter>
+
+  <filter-mapping>
+    <filter-name>request-capture</filter-name>
+    <url-pattern>*</url-pattern>
+  </filter-mapping>
+
+  <filter>
+    <filter-name>Host Page Patch</filter-name>
+    <filter-class>org.jboss.errai.security.server.servlet.UserHostPageFilter</filter-class>
+  </filter>
+
+  <filter-mapping>
+    <filter-name>Host Page Patch</filter-name>
+    <url-pattern>/kie-wb.html</url-pattern>
+  </filter-mapping>
+
+  <filter>
     <filter-name>UberFire Security Headers Filter</filter-name>
     <filter-class>org.uberfire.ext.security.server.SecureHeadersFilter</filter-class>
     <init-param>

--- a/kie-wb/kie-wb-webapp/src/main/resources/ErraiApp.properties
+++ b/kie-wb/kie-wb-webapp/src/main/resources/ErraiApp.properties
@@ -30,4 +30,4 @@
 # file, although it is rarely necessary. See the documentation at
 # https://docs.jboss.org/author/display/ERRAI/ErraiApp.properties
 # for details.
-errai.security.user_cookie_enabled=true
+errai.security.user_on_hostpage_enabled=true

--- a/kie-wb/kie-wb-webapp/src/main/resources/application-roles.properties
+++ b/kie-wb/kie-wb-webapp/src/main/resources/application-roles.properties
@@ -1,4 +1,5 @@
-admin=admin,users,director,manager,kiemgmt
+admin=t0,t1,t2,t3,t4,t5,t6,t7,t8,t9,t10,t11,t12,t13,t14,t15,t16,t17,t18,t19,t20,t21,t22,t23,t24,t25,t26,t27,t28,t29,t30,t31,t32,t33,t34,t35,t36,t37,t38,t39,t40,t41,t42,t43,t44,t45,t46,t47,t48,t49,t50,t51,t52,t53,t54,t55,t56,t57,t58,t59,t60,t61,t62,t63,t64,t65,t66,t67,t68,t69,t70,t71,t72,t73,t74,t75,t76,t77,t78,t79,admin,developer,analyst,user,manager
+#admin=t0,admin,developer,analyst,user,manager
 salaboy=user,admin,IT,HR,Accounting
 maciej=user,admin,Translator
 kris=user,admin,Reviewer

--- a/kie-wb/kie-wb-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/kie-wb/kie-wb-webapp/src/main/webapp/WEB-INF/web.xml
@@ -26,6 +26,16 @@
   </filter-mapping>
 
   <filter>
+    <filter-name>Host Page Patch</filter-name>
+    <filter-class>org.jboss.errai.security.server.servlet.UserHostPageFilter</filter-class>
+  </filter>
+
+  <filter-mapping>
+    <filter-name>Host Page Patch</filter-name>
+    <url-pattern>/kie-wb.html</url-pattern>
+  </filter-mapping>
+
+  <filter>
     <filter-name>UberFire Security Headers Filter</filter-name>
     <filter-class>org.uberfire.ext.security.server.SecureHeadersFilter</filter-class>
     <init-param>


### PR DESCRIPTION
of the number of roles/groups of a user, can be reached. new solution
`patches` the host page (UserHostPageFilter) with user's info that now
is supported on errai client security.