### PR TITLE
[BZ-1187211] remove dependency on private modules for EAP and WildFly distros

### DIFF
--- a/kie-drools-wb/kie-drools-wb-distribution-wars/pom.xml
+++ b/kie-drools-wb/kie-drools-wb-distribution-wars/pom.xml
@@ -95,11 +95,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.jgroups</groupId>
-      <artifactId>jgroups</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>jaxrs-api</artifactId>
     </dependency>
@@ -142,11 +137,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.javassist</groupId>
-      <artifactId>javassist</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
     </dependency>
@@ -177,30 +167,6 @@
     <dependency>
       <groupId>antlr</groupId>
       <artifactId>antlr</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>commons-cli</groupId>
-      <artifactId>commons-cli</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>commons-codec</groupId>
-      <artifactId>commons-codec</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>commons-collections</groupId>
-      <artifactId>commons-collections</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>commons-configuration</groupId>
-      <artifactId>commons-configuration</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>commons-io</groupId>
-      <artifactId>commons-io</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>commons-lang</groupId>
-      <artifactId>commons-lang</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.cxf</groupId>
@@ -247,10 +213,6 @@
       <artifactId>dom4j</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.sun.xml.bind</groupId>
       <artifactId>jaxb-impl</artifactId>
     </dependency>
@@ -267,20 +229,8 @@
       <artifactId>jcl-over-slf4j</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.jdom</groupId>
-      <artifactId>jdom</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>joda-time</groupId>
-      <artifactId>joda-time</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.neethi</groupId>
       <artifactId>neethi</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -291,38 +241,12 @@
       <artifactId>slf4j-jdk14</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.yaml</groupId>
-      <artifactId>snakeyaml</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.velocity</groupId>
-      <artifactId>velocity</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.codehaus.woodstox</groupId>
       <artifactId>woodstox-core-asl</artifactId>
     </dependency>
     <dependency>
       <groupId>wsdl4j</groupId>
       <artifactId>wsdl4j</artifactId>
-    </dependency>
-
-    <!--weblogic-->
-    <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-core-asl</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-jaxrs</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-mapper-asl</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-xc</artifactId>
     </dependency>
 
     <dependency>
@@ -360,11 +284,6 @@
     <dependency>
       <groupId>org.codehaus.woodstox</groupId>
       <artifactId>stax2-api</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
     </dependency>
 
   </dependencies>

--- a/kie-drools-wb/kie-drools-wb-distribution-wars/src/main/assembly/component-kie-drools-wb-eap-6_4-common.xml
+++ b/kie-drools-wb/kie-drools-wb-distribution-wars/src/main/assembly/component-kie-drools-wb-eap-6_4-common.xml
@@ -24,10 +24,6 @@
           <exclude>WEB-INF/jboss-deployment-structure.xml</exclude>
 
           <exclude>WEB-INF/classes/org/kie/workbench/backend/weblogic/</exclude>
-          <!-- EAP 6.4 alignment -->
-          <exclude>WEB-INF/lib/ecj-*.jar</exclude>
-          <!-- this *.jar is not in the AS 7.1.1 -->
-          <exclude>WEB-INF/lib/guava-*.jar</exclude>
           <!-- Errai 1.1+ CDI Compat -->
           <exclude>WEB-INF/lib/errai-weld-integration-*.jar</exclude>
         </excludes>

--- a/kie-drools-wb/kie-drools-wb-distribution-wars/src/main/assembly/component-kie-drools-wb-tomcat-7-common.xml
+++ b/kie-drools-wb/kie-drools-wb-distribution-wars/src/main/assembly/component-kie-drools-wb-tomcat-7-common.xml
@@ -11,36 +11,21 @@
     <dependencySet>
       <includes>
         <include>antlr:antlr</include>
-        <include>commons-cli:commons-cli</include>
-        <include>commons-codec:commons-codec</include>
-        <include>commons-collections:commons-collections</include>
-        <include>commons-configuration:commons-configuration</include>
-        <include>commons-io:commons-io</include>
-        <include>commons-io:commons-io</include>
-        <include>commons-lang:commons-lang</include>
-        <include>org.apache.cxf:*</include>
         <include>dom4j:dom4j</include>
-        <include>org.apache.httpcomponents:httpclient</include>
+        <include>org.apache.cxf:*</include>
+        <include>org.apache.neethi:neethi</include>
         <include>org.hibernate.javax.persistence:hibernate-jpa-2.0-api</include>
         <include>org.hibernate:hibernate-entitymanager</include>
         <include>org.hibernate:hibernate-core</include>
         <include>org.hibernate:hibernate-validator</include>
         <include>org.hibernate.common:hibernate-commons-annotations</include>
-        <include>com.sun.xml.bind:jaxb-impl</include>
         <include>com.sun.xml.bind:jaxb-xjc</include>
         <include>org.jboss.logging:jboss-logging</include>
         <include>org.slf4j:jcl-over-slf4j</include>
-        <include>org.jdom:jdom</include>
-        <include>joda-time:joda-time</include>
-        <include>org.apache.neethi:neethi</include>
         <include>org.slf4j:slf4j-ext</include>
-        <include>org.yaml:snakeyaml</include>
-        <include>org.apache.velocity:velocity</include>
+        <include>org.codehaus.jackson:jackson-jaxrs</include>
         <include>org.codehaus.woodstox:woodstox-core-asl</include>
         <include>org.codehaus.woodstox:stax2-api</include>
-        <include>wsdl4j:wsdl4j</include>
-
-        <include>org.codehaus.jackson:*</include>
 
         <include>com.h2database:h2</include>
         <include>ch.qos.cal10n:cal10n-api</include>
@@ -49,6 +34,7 @@
         <include>javax.inject:javax.inject</include>
         <include>javax.mail:mail</include>
         <include>javax.validation:validation-api</include>
+        <include>net.jcip:jcip-annotations</include>
 
         <include>org.jboss.spec.javax.annotation:jboss-annotations-api_1.1_spec</include>
         <include>org.jboss.spec.javax.interceptor:jboss-interceptors-api_1.1_spec</include>
@@ -59,9 +45,7 @@
         <include>org.jboss.spec.javax.xml.bind:jboss-jaxb-api_2.2_spec</include>
         <include>org.jboss.spec.javax.ejb:jboss-ejb-api_3.1_spec</include>
 
-        <include>org.javassist:javassist</include>
         <include>org.jboss.logging:jboss-logging</include>
-        <include>org.jgroups:jgroups</include>
         <include>org.jboss.resteasy:jaxrs-api</include>
         <include>org.jboss.resteasy:resteasy-jaxrs</include>
         <include>org.jboss.resteasy:resteasy-cdi</include>
@@ -74,13 +58,11 @@
         <include>org.jboss.weld.servlet:weld-servlet-core</include>
         <include>org.jboss.weld:weld-spi</include>
 
-        <include>net.jcip:jcip-annotations</include>
+        <include>wsdl4j:wsdl4j</include>
         <include>xalan:xalan</include>
         <include>xalan:serializer</include>
         <include>xerces:xercesImpl</include>
         <include>xml-resolver:xml-resolver</include>
-
-        <include>org.osgi:org.osgi.core</include>
       </includes>
       <unpack>false</unpack>
       <outputDirectory>WEB-INF/lib</outputDirectory>

--- a/kie-drools-wb/kie-drools-wb-distribution-wars/src/main/assembly/component-kie-drools-wb-weblogic-12-common.xml
+++ b/kie-drools-wb/kie-drools-wb-distribution-wars/src/main/assembly/component-kie-drools-wb-weblogic-12-common.xml
@@ -15,36 +15,23 @@
     <dependencySet>
       <includes>
         <include>antlr:antlr</include>
-        <include>commons-cli:commons-cli</include>
-        <include>commons-codec:commons-codec</include>
-        <include>commons-collections:commons-collections</include>
-        <include>commons-configuration:commons-configuration</include>
-        <include>commons-io:commons-io</include>
-        <include>commons-lang:commons-lang</include>
-        <include>org.apache.cxf:*</include>
         <include>dom4j:dom4j</include>
-        <include>org.apache.httpcomponents:httpclient</include>
+        <include>org.apache.cxf:*</include>
+        <include>org.apache.neethi:neethi</include>
+        <include>org.codehaus.jackson:jackson-jaxrs</include>
+        <include>org.codehaus.woodstox:woodstox-core-asl</include>
         <include>org.hibernate:hibernate-entitymanager</include>
         <include>org.hibernate:hibernate-core</include>
         <include>org.hibernate:hibernate-validator</include>
         <include>org.hibernate.common:hibernate-commons-annotations</include>
-        <include>com.sun.xml.bind:jaxb-impl</include>
         <include>com.sun.xml.bind:jaxb-xjc</include>
         <include>org.jboss.logging:jboss-logging</include>
         <include>org.slf4j:jcl-over-slf4j</include>
-        <include>org.jdom:jdom</include>
-        <include>joda-time:joda-time</include>
-        <include>org.apache.neethi:neethi</include>
         <include>org.slf4j:slf4j-api</include>
         <include>org.slf4j:slf4j-ext</include>
         <include>org.slf4j:slf4j-jdk14:jar</include>
-        <include>org.yaml:snakeyaml</include>
-        <include>org.apache.velocity:velocity</include>
-        <include>org.codehaus.woodstox:woodstox-core-asl</include>
         <include>wsdl4j:wsdl4j</include>
         <include>xerces:xercesImpl</include>
-
-        <include>org.codehaus.jackson:*</include>
       </includes>
       <unpack>false</unpack>
       <outputDirectory>WEB-INF/lib</outputDirectory>
@@ -83,6 +70,9 @@
           <exclude>WEB-INF/lib/errai-jboss-as-support-*.jar</exclude>
           <!-- Errai 1.1+ CDI Compat -->
           <exclude>WEB-INF/lib/errai-weld-integration-*.jar</exclude>
+          <exclude>WEB-INF/lib/org.osgi.core-*.jar</exclude>
+          <exclude>WEB-INF/lib/javassist-*.jar</exclude>
+          <exclude>WEB-INF/lib/jgroups-*.jar</exclude>
         </excludes>
       </unpackOptions>
       <useStrictFiltering>true</useStrictFiltering>

--- a/kie-drools-wb/kie-drools-wb-distribution-wars/src/main/assembly/component-kie-drools-wb-websphere-as-8-common.xml
+++ b/kie-drools-wb/kie-drools-wb-distribution-wars/src/main/assembly/component-kie-drools-wb-websphere-as-8-common.xml
@@ -15,31 +15,19 @@
     <dependencySet>
       <includes>
         <include>antlr:antlr</include>
-        <include>commons-cli:commons-cli</include>
-        <include>commons-codec:commons-codec</include>
-        <include>commons-collections:commons-collections</include>
-        <include>commons-configuration:commons-configuration</include>
-        <include>commons-io:commons-io</include>
-        <include>commons-lang:commons-lang</include>
-        <include>org.apache.cxf:*</include>
         <include>dom4j:dom4j</include>
-        <include>org.apache.httpcomponents:httpclient</include>
+        <include>org.apache.cxf:*</include>
+        <include>org.apache.neethi:neethi</include>
         <include>org.hibernate:hibernate-entitymanager</include>
         <include>org.hibernate:hibernate-core</include>
         <include>org.hibernate:hibernate-validator</include>
         <include>org.hibernate.common:hibernate-commons-annotations</include>
-        <include>com.sun.xml.bind:jaxb-impl</include>
         <include>com.sun.xml.bind:jaxb-xjc</include>
         <include>org.jboss.logging:jboss-logging</include>
         <include>org.slf4j:jcl-over-slf4j</include>
-        <include>org.jdom:jdom</include>
-        <include>joda-time:joda-time</include>
-        <include>org.apache.neethi:neethi</include>
         <include>org.slf4j:slf4j-api</include>
         <include>org.slf4j:slf4j-ext</include>
         <include>org.slf4j:slf4j-jdk14:jar</include>
-        <include>org.yaml:snakeyaml</include>
-        <include>org.apache.velocity:velocity</include>
         <include>org.codehaus.woodstox:woodstox-core-asl</include>
         <include>org.codehaus.woodstox:stax2-api</include>
         <include>wsdl4j:wsdl4j</include>
@@ -85,6 +73,10 @@
           <exclude>WEB-INF/lib/errai-jboss-as-support-*.jar</exclude>
           <!-- Errai 1.1+ CDI Compat -->
           <exclude>WEB-INF/lib/errai-weld-integration-*.jar</exclude>
+          <exclude>WEB-INF/lib/org.osgi.core-*.jar</exclude>
+          <exclude>WEB-INF/lib/javassist-*.jar</exclude>
+          <exclude>WEB-INF/lib/jgroups-*.jar</exclude>
+          <exclude>WEB-INF/lib/jackson-*.jar</exclude>
         </excludes>
       </unpackOptions>
       <useStrictFiltering>true</useStrictFiltering>

--- a/kie-drools-wb/kie-drools-wb-distribution-wars/src/main/assembly/eap6_4/WEB-INF/jboss-deployment-structure.xml
+++ b/kie-drools-wb/kie-drools-wb-distribution-wars/src/main/assembly/eap6_4/WEB-INF/jboss-deployment-structure.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~ JBoss, Home of Professional Open Source
-  ~ Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+  ~ Copyright 2015 Red Hat Inc. and/or its affiliates and other contributors
   ~ as indicated by the @author tags. All rights reserved.
   ~ See the copyright.txt in the distribution for a
   ~ full listing of individual contributors.
@@ -18,71 +18,46 @@
   ~ MA  02110-1301, USA.
   -->
 <jboss-deployment-structure xmlns="urn:jboss:deployment-structure:1.0">
-    <deployment>
-        <dependencies>
-            <module name="org.jboss.netty" />
-            <!-- EAP alignement -->
-            <module name="javax.activation.api" />
-            <module name="org.antlr" />
-            <module name="org.apache.commons.cli" />
-            <module name="org.apache.commons.collections" />
-            <module name="org.apache.commons.lang" />
-            <module name="org.apache.commons.codec" />
-            <module name="org.apache.commons.io" />
-            <module name="com.sun.xml.bind" />
-            <module name="org.osgi.core" />
-            <module name="org.yaml.snakeyaml" />
-            <module name="org.apache.cxf.impl" />
-            <module name="org.dom4j" />
-            <module name="org.jboss.as.web" /> <!-- this jar (ecj) is only in EAP 6.1, not in AS 7.1.1 -->
-            <module name="com.google.guava" />
-            <module name="com.h2database.h2" />
-            <module name="org.hibernate.commons-annotations" />
-            <module name="org.hibernate" />
-            <module name="javax.persistence.api" />
-            <module name="org.hibernate.validator" />
-            <module name="org.hornetq" />
-            <module name="org.codehaus.jackson.jackson-core-asl" />
-            <module name="org.codehaus.jackson.jackson-jaxrs" />
-            <module name="org.codehaus.jackson.jackson-mapper-asl" />
-            <module name="org.codehaus.jackson.jackson-xc" />
-            <module name="org.javassist" />
-            <module name="javax.ejb.api" />
-            <module name="org.slf4j.jcl-over-slf4j" />
-            <module name="org.jdom" />
-            <module name="org.codehaus.jettison" />
-            <module name="org.joda.time" />
-            <module name="javax.faces.api" />  <!-- check 1.2 -->
-            <module name="org.slf4j" />
-            <module name="org.slf4j.ext" />
-            <module name="org.apache.velocity" />
-            <module name="org.codehaus.woodstox" />
-            <module name="javax.wsdl4j.api" />
-            <module name="org.apache.xalan" />
-            <module name="org.apache.xerces" />
+  <deployment>
+    <dependencies>
+      <!-- IMPORTANT: when adding dependency (module) here, make sure it is a public one.
+           Do not add private modules as there is no guarantee they won't be changed or
+           removed in future. EAP also generates warning(s) during the deployment if
+           the WAR depends on private modules. -->
+      <!-- Keep the alphabetical order! -->
+      <module name="javax.activation.api"/>
+      <module name="javax.ejb.api"/>
+      <module name="javax.faces.api"/>
+      <module name="javax.jms.api"/>
+      <module name="javax.validation.api"/>
+      <module name="javax.persistence.api"/>
+      <module name="javax.servlet.api"/>
+      <module name="javax.transaction.api"/>
+      <module name="javax.wsdl4j.api"/>
+      <module name="org.apache.cxf"/>
+      <module name="org.apache.xalan"/>
+      <module name="org.apache.xerces"/>
+      <module name="org.hibernate"/>
+      <module name="org.hibernate.commons-annotations"/>
+      <module name="org.hibernate.validator"/>
+      <module name="org.jboss.ejb-client"/>
+      <module name="org.jboss.logging"/>
+      <module name="org.jboss.logmanager"/>
+      <module name="org.jboss.marshalling"/>
+      <module name="org.jboss.remote-naming"/>
+      <module name="org.jboss.remoting3"/>
+      <module name="org.jboss.xnio"/>
+      <module name="org.slf4j"/>
+      <module name="org.slf4j.ext"/>
+      <module name="org.slf4j.jcl-over-slf4j"/>
 
-            <!-- transitive dependencies -->
-            <module name="org.apache.james.mime4j" />
-            <module name="org.apache.commons.configuration" />
-            <module name="org.apache.cxf" />
-            <module name="org.apache.httpcomponents" />
-            <module name="org.jboss.ejb-client" />
-            <module name="javax.jms.api" />
-            <module name="org.jboss.logging" />
-            <module name="org.jboss.logmanager" />
-            <module name="org.jboss.marshalling" />
-            <module name="org.jboss.remote-naming" />
-            <module name="org.jboss.remoting3" />
-            <module name="org.jboss.sasl" />
-            <module name="javax.servlet.api" />
-            <module name="javax.transaction.api" />
-            <module name="org.jgroups" />
-            <module name="org.apache.neethi" />
-            <module name="org.apache.xalan" />
-            <module name="javax.validation.api" />
-            <module name="org.apache.xml-resolver" />
-            <module name="org.jboss.xnio" />
-        </dependencies>
-    </deployment>
+      <!-- EXCEPTIONS - private/unsupported modules that can not be directly added into the WEB-INF/lib -->
+      <!-- Dom4j is a transitive dependency of drools-decisiontables and needs to be on classpath.
+           It is also used by Hibernate and adding it directly into WEB-INF/lib results in
+           "org.dom4j.DocumentException: org.dom4j.DocumentFactory cannot be cast to org.dom4j.DocumentFactory"
+           Depending on the EAP module seems to be the only way.
+           See https://developer.jboss.org/thread/173306 for more info. -->
+      <module name="org.dom4j"/>
+    </dependencies>
+  </deployment>
 </jboss-deployment-structure>
-

--- a/kie-drools-wb/kie-drools-wb-webapp/pom.xml
+++ b/kie-drools-wb/kie-drools-wb-webapp/pom.xml
@@ -134,81 +134,6 @@
     </dependency>
 
     <dependency>
-      <groupId>commons-configuration</groupId>
-      <artifactId>commons-configuration</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>commons-collections</groupId>
-      <artifactId>commons-collections</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>commons-io</groupId>
-      <artifactId>commons-io</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>commons-lang</groupId>
-      <artifactId>commons-lang</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>commons-logging</groupId>
-      <artifactId>commons-logging</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>commons-codec</groupId>
-      <artifactId>commons-codec</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>commons-cli</groupId>
-      <artifactId>commons-cli</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>dom4j</groupId>
-      <artifactId>dom4j</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-jaxrs</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-xc</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-core-asl</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-mapper-asl</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.javassist</groupId>
-      <artifactId>javassist</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jdom</groupId>
-      <artifactId>jdom</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.velocity</groupId>
-      <artifactId>velocity</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>xalan</groupId>
       <artifactId>xalan</artifactId>
       <scope>provided</scope>
@@ -223,27 +148,6 @@
       <artifactId>xercesImpl</artifactId>
       <scope>provided</scope>
     </dependency>
-    <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jgroups</groupId>
-      <artifactId>jgroups</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>joda-time</groupId>
-      <artifactId>joda-time</artifactId>
-      <scope>provided</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.yaml</groupId>
-      <artifactId>snakeyaml</artifactId>
-      <scope>provided</scope>
-    </dependency>
 
     <dependency>
       <groupId>org.scannotation</groupId>
@@ -254,6 +158,12 @@
           <artifactId>javassist</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>dom4j</groupId>
+      <artifactId>dom4j</artifactId>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>
@@ -270,6 +180,10 @@
       <groupId>org.apache.abdera</groupId>
       <artifactId>abdera-core</artifactId>
       <exclusions>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
         <exclusion>
           <groupId>org.apache.geronimo.specs</groupId>
           <artifactId>geronimo-stax-api_1.0_spec</artifactId>
@@ -301,6 +215,12 @@
     <dependency>
       <groupId>org.kie</groupId>
       <artifactId>kie-ci</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!--Logs-->
@@ -325,8 +245,8 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
+      <groupId>org.slf4j</groupId>
+      <artifactId>log4j-over-slf4j</artifactId>
       <scope>provided</scope>
     </dependency>
 
@@ -750,6 +670,10 @@
           <groupId>org.jbpm</groupId>
           <artifactId>jbpm-workitems</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 
@@ -781,6 +705,16 @@
       <groupId>org.dashbuilder</groupId>
       <artifactId>dashbuilder-dataset-client</artifactId>
       <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-log4j12</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
@@ -817,6 +751,16 @@
       <groupId>org.dashbuilder</groupId>
       <artifactId>dashbuilder-widgets</artifactId>
       <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-log4j12</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
@@ -872,6 +816,12 @@
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-io</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.uberfire</groupId>
@@ -1043,6 +993,16 @@
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-ui</artifactId>
       <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jboss.errai</groupId>
@@ -1088,11 +1048,7 @@
       <artifactId>gwt-user</artifactId>
       <scope>provided</scope>
     </dependency>
-    <!--<dependency>-->
-    <!--<groupId>com.google.gwt</groupId>-->
-    <!--<artifactId>gwt-servlet</artifactId>-->
-    <!--<scope>provided</scope>-->
-    <!--</dependency>-->
+
     <dependency>
       <groupId>com.github.gwtbootstrap</groupId>
       <artifactId>gwt-bootstrap</artifactId>
@@ -1102,25 +1058,6 @@
     <dependency>
       <groupId>org.owasp.encoder</groupId>
       <artifactId>encoder</artifactId>
-    </dependency>
-
-    <!-- Rogue imports to avoid OSGi errors -->
-    <dependency>
-      <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
-      <scope>provided</scope>
-    </dependency>
-
-    <!-- JAXB -->
-    <dependency>
-      <groupId>com.sun.xml.bind</groupId>
-      <artifactId>jaxb-impl</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.sun.xml.bind</groupId>
-      <artifactId>jaxb-xjc</artifactId>
-      <scope>provided</scope>
     </dependency>
 
     <!--JUnit for Test scenarios -->
@@ -1326,7 +1263,9 @@
           <configuration>
             <deploy>${project.build.directory}/gwt-symbols-deploy</deploy>
             <localWorkers>${gwt.compiler.localWorkers}</localWorkers>
-            <extraJvmArgs>-Xmx4096m -Xms1024m -XX:MaxPermSize=256m -XX:PermSize=128m -Xss1M -XX:CompileThreshold=7000 -Derrai.jboss.home=${errai.jboss.home} -Dorg.kie.demo=true -Dorg.kie.clean.onstartup=true -Dorg.jbpm.designer.perspective=ruleflow -Djava.util.prefs.syncInterval=2000000</extraJvmArgs>
+            <extraJvmArgs>-Xmx4096m -Xms1024m -XX:MaxPermSize=256m -XX:PermSize=128m -Xss1M -XX:CompileThreshold=7000 -Derrai.jboss.home=${errai.jboss.home} -Dorg.kie.demo=true
+              -Dorg.kie.clean.onstartup=true -Dorg.jbpm.designer.perspective=ruleflow -Djava.util.prefs.syncInterval=2000000
+            </extraJvmArgs>
             <draftCompile>true</draftCompile>
             <module>org.kie.workbench.drools.FastCompiledKIEDroolsWebapp</module>
             <logLevel>INFO</logLevel>

--- a/kie-drools-wb/kie-drools-wb-webapp/src/main/webapp/META-INF/MANIFEST.MF
+++ b/kie-drools-wb/kie-drools-wb-webapp/src/main/webapp/META-INF/MANIFEST.MF
@@ -1,1 +1,0 @@
-Dependencies: org.jboss.as.naming,org.jboss.as.server,org.jboss.msc

--- a/kie-drools-wb/kie-drools-wb-webapp/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/kie-drools-wb/kie-drools-wb-webapp/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~ JBoss, Home of Professional Open Source
-  ~ Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+  ~ Copyright 2015 Red Hat Inc. and/or its affiliates and other contributors
   ~ as indicated by the @author tags. All rights reserved.
   ~ See the copyright.txt in the distribution for a
   ~ full listing of individual contributors.
@@ -20,74 +20,44 @@
 <jboss-deployment-structure xmlns="urn:jboss:deployment-structure:1.0">
   <deployment>
     <dependencies>
-      <!-- We need org.jboss.netty not io.netty bundled with Wildfly -->
-      <!--<module name="io.netty" />-->
-
-      <!-- EAP alignement -->
+      <!-- IMPORTANT: when adding dependency (module) here, make sure it is a public one.
+           Do not add private modules as there is no guarantee they won't be changed or
+           removed in future. WildFly also generates warning(s) during the deployment if
+           the WAR depends on private modules. -->
+      <!-- Keep the alphabetical order! -->
       <module name="javax.activation.api"/>
-      <module name="org.antlr"/>
-      <module name="org.apache.commons.cli"/>
-      <module name="org.apache.commons.collections"/>
-      <module name="org.apache.commons.lang"/>
-      <module name="org.apache.commons.codec"/>
-      <module name="org.apache.commons.io"/>
-      <module name="com.sun.xml.bind"/>
-      <module name="org.osgi.core"/>
-      <module name="org.yaml.snakeyaml"/>
-      <module name="org.apache.cxf.impl"/>
-      <module name="org.dom4j"/>
-      <module name="org.jboss.as.web"/>
-      <!-- this jar (ecj) is only in EAP 6.1, not in AS 7.1.1 -->
-      <!-- Exclude com.google.guava:guava:16.0.1 provided by Wildfly as we need com.google.guava:guava:13.0.1 -->
-      <!--<module name="com.google.guava" />-->
-      <module name="com.h2database.h2"/>
-      <module name="org.hibernate.commons-annotations"/>
-      <module name="org.hibernate"/>
-      <module name="javax.persistence.api"/>
-      <module name="org.hibernate.validator"/>
-      <module name="org.hornetq"/>
-      <module name="org.codehaus.jackson.jackson-core-asl"/>
-      <module name="org.codehaus.jackson.jackson-jaxrs"/>
-      <module name="org.codehaus.jackson.jackson-mapper-asl"/>
-      <module name="org.codehaus.jackson.jackson-xc"/>
-      <module name="org.javassist"/>
       <module name="javax.ejb.api"/>
-      <module name="org.slf4j.jcl-over-slf4j"/>
-      <module name="org.jdom"/>
-      <module name="org.codehaus.jettison"/>
-      <module name="org.joda.time"/>
       <module name="javax.faces.api"/>
-      <!-- check 1.2 -->
-      <module name="org.slf4j"/>
-      <module name="org.slf4j.ext"/>
-      <module name="org.apache.velocity"/>
-      <module name="org.codehaus.woodstox"/>
+      <module name="javax.jms.api"/>
+      <module name="javax.validation.api"/>
+      <module name="javax.persistence.api"/>
+      <module name="javax.servlet.api"/>
+      <module name="javax.transaction.api"/>
       <module name="javax.wsdl4j.api"/>
+      <module name="org.apache.cxf"/>
       <module name="org.apache.xalan"/>
       <module name="org.apache.xerces"/>
-
-      <!-- transitive dependencies -->
-      <module name="org.apache.james.mime4j"/>
-      <module name="org.apache.commons.configuration"/>
-      <module name="org.apache.cxf"/>
-      <module name="org.apache.httpcomponents"/>
+      <module name="org.hibernate"/>
+      <module name="org.hibernate.commons-annotations"/>
+      <module name="org.hibernate.validator"/>
       <module name="org.jboss.ejb-client"/>
-      <module name="javax.jms.api"/>
       <module name="org.jboss.logging"/>
       <module name="org.jboss.logmanager"/>
       <module name="org.jboss.marshalling"/>
       <module name="org.jboss.remote-naming"/>
       <module name="org.jboss.remoting3"/>
-      <module name="org.jboss.sasl"/>
-      <module name="javax.servlet.api"/>
-      <module name="javax.transaction.api"/>
-      <module name="org.jgroups"/>
-      <module name="org.apache.neethi"/>
-      <module name="org.apache.xalan"/>
-      <module name="javax.validation.api"/>
-      <module name="org.apache.xml-resolver"/>
       <module name="org.jboss.xnio"/>
+      <module name="org.slf4j"/>
+      <module name="org.slf4j.ext"/>
+      <module name="org.slf4j.jcl-over-slf4j"/>
+
+      <!-- EXCEPTIONS - private/unsupported modules that can not be directly added into the WEB-INF/lib -->
+      <!-- Dom4j is a transitive dependency of drools-decisiontables and needs to be on classpath.
+           It is also used by Hibernate and adding it directly into WEB-INF/lib results in
+           "org.dom4j.DocumentException: org.dom4j.DocumentFactory cannot be cast to org.dom4j.DocumentFactory"
+           Depending on the EAP module seems to be the only way.
+           See https://developer.jboss.org/thread/173306 for more info. -->
+      <module name="org.dom4j"/>
     </dependencies>
   </deployment>
 </jboss-deployment-structure>
-

--- a/kie-wb/kie-wb-distribution-wars/pom.xml
+++ b/kie-wb/kie-wb-distribution-wars/pom.xml
@@ -94,11 +94,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.jgroups</groupId>
-      <artifactId>jgroups</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>jaxrs-api</artifactId>
     </dependency>
@@ -178,30 +173,6 @@
       <artifactId>antlr</artifactId>
     </dependency>
     <dependency>
-      <groupId>commons-cli</groupId>
-      <artifactId>commons-cli</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>commons-codec</groupId>
-      <artifactId>commons-codec</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>commons-collections</groupId>
-      <artifactId>commons-collections</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>commons-configuration</groupId>
-      <artifactId>commons-configuration</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>commons-io</groupId>
-      <artifactId>commons-io</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>commons-lang</groupId>
-      <artifactId>commons-lang</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.cxf</groupId>
       <artifactId>cxf-api</artifactId>
     </dependency>
@@ -246,10 +217,6 @@
       <artifactId>dom4j</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.sun.xml.bind</groupId>
       <artifactId>jaxb-impl</artifactId>
     </dependency>
@@ -260,18 +227,6 @@
     <dependency>
       <groupId>org.jboss.logging</groupId>
       <artifactId>jboss-logging</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>jcl-over-slf4j</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.jdom</groupId>
-      <artifactId>jdom</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>joda-time</groupId>
-      <artifactId>joda-time</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.neethi</groupId>
@@ -287,15 +242,11 @@
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
+      <artifactId>jcl-over-slf4j</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
       <artifactId>slf4j-jdk14</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.yaml</groupId>
-      <artifactId>snakeyaml</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.velocity</groupId>
-      <artifactId>velocity</artifactId>
     </dependency>
     <dependency>
       <groupId>org.codehaus.woodstox</groupId>
@@ -304,24 +255,6 @@
     <dependency>
       <groupId>wsdl4j</groupId>
       <artifactId>wsdl4j</artifactId>
-    </dependency>
-
-    <!--weblogic-->
-    <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-core-asl</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-jaxrs</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-mapper-asl</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-xc</artifactId>
     </dependency>
 
     <dependency>
@@ -367,10 +300,6 @@
       <artifactId>errai-weld-integration</artifactId>
     </dependency>
 
-    <dependency>
-      <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
-    </dependency>
   </dependencies>
 
   <build>

--- a/kie-wb/kie-wb-distribution-wars/src/main/assembly/component-kie-wb-eap-6_4-common.xml
+++ b/kie-wb/kie-wb-distribution-wars/src/main/assembly/component-kie-wb-eap-6_4-common.xml
@@ -24,9 +24,6 @@
             <exclude>WEB-INF/jboss-deployment-structure.xml</exclude>
 
             <exclude>WEB-INF/classes/org/kie/workbench/backend/weblogic/</exclude>
-            <!-- EAP 6.4 alignment -->
-            <exclude>WEB-INF/lib/ecj-*.jar</exclude> <!-- this *.jar is not in the AS 7.1.1 -->
-            <exclude>WEB-INF/lib/guava-*.jar</exclude>
             <!-- Errai 1.1+ CDI Compat -->
             <exclude>WEB-INF/lib/errai-weld-integration-*.jar</exclude>
           </excludes>

--- a/kie-wb/kie-wb-distribution-wars/src/main/assembly/component-kie-wb-tomcat-7-common.xml
+++ b/kie-wb/kie-wb-distribution-wars/src/main/assembly/component-kie-wb-tomcat-7-common.xml
@@ -11,36 +11,21 @@
       <dependencySet>
         <includes>
           <include>antlr:antlr</include>
-          <include>commons-cli:commons-cli</include>
-          <include>commons-codec:commons-codec</include>
-          <include>commons-collections:commons-collections</include>
-          <include>commons-configuration:commons-configuration</include>
-          <include>commons-io:commons-io</include>
-          <include>commons-io:commons-io</include>
-          <include>commons-lang:commons-lang</include>
           <include>org.apache.cxf:*</include>
+          <include>org.apache.neethi:neethi</include>
           <include>dom4j:dom4j</include>
-          <include>org.apache.httpcomponents:httpclient</include>
           <include>org.hibernate.javax.persistence:hibernate-jpa-2.0-api</include>
           <include>org.hibernate:hibernate-entitymanager</include>
           <include>org.hibernate:hibernate-core</include>
           <include>org.hibernate:hibernate-validator</include>
           <include>org.hibernate.common:hibernate-commons-annotations</include>
-          <include>com.sun.xml.bind:jaxb-impl</include>
           <include>com.sun.xml.bind:jaxb-xjc</include>
           <include>org.jboss.logging:jboss-logging</include>
           <include>org.slf4j:jcl-over-slf4j</include>
-          <include>org.jdom:jdom</include>
-          <include>joda-time:joda-time</include>
-          <include>org.apache.neethi:neethi</include>
           <include>org.slf4j:slf4j-ext</include>
-          <include>org.yaml:snakeyaml</include>
-          <include>org.apache.velocity:velocity</include>
           <include>org.codehaus.woodstox:woodstox-core-asl</include>
           <include>org.codehaus.woodstox:stax2-api</include>
           <include>wsdl4j:wsdl4j</include>
-
-          <include>org.codehaus.jackson:*</include>
 
           <include>com.h2database:h2</include>
           <include>ch.qos.cal10n:cal10n-api</include>
@@ -59,9 +44,7 @@
           <include>org.jboss.spec.javax.xml.bind:jboss-jaxb-api_2.2_spec</include>
           <include>org.jboss.spec.javax.ejb:jboss-ejb-api_3.1_spec</include>
 
-          <include>org.javassist:javassist</include>
           <include>org.jboss.logging:jboss-logging</include>
-          <include>org.jgroups:jgroups</include>
           <include>org.jboss.resteasy:jaxrs-api</include>
           <include>org.jboss.resteasy:resteasy-jaxrs</include>
           <include>org.jboss.resteasy:resteasy-cdi</include>
@@ -79,8 +62,6 @@
           <include>xalan:serializer</include>
           <include>xerces:xercesImpl</include>
           <include>xml-resolver:xml-resolver</include>
-
-          <include>org.osgi:org.osgi.core</include>
         </includes>
         <unpack>false</unpack>
         <outputDirectory>WEB-INF/lib</outputDirectory>

--- a/kie-wb/kie-wb-distribution-wars/src/main/assembly/component-kie-wb-weblogic-12-common.xml
+++ b/kie-wb/kie-wb-distribution-wars/src/main/assembly/component-kie-wb-weblogic-12-common.xml
@@ -15,36 +15,22 @@
       <dependencySet>
         <includes>
           <include>antlr:antlr</include>
-          <include>commons-cli:commons-cli</include>
-          <include>commons-codec:commons-codec</include>
-          <include>commons-collections:commons-collections</include>
-          <include>commons-configuration:commons-configuration</include>
-          <include>commons-io:commons-io</include>
-          <include>commons-lang:commons-lang</include>
           <include>org.apache.cxf:*</include>
+          <include>org.apache.neethi:neethi</include>
           <include>dom4j:dom4j</include>
-          <include>org.apache.httpcomponents:httpclient</include>
           <include>org.hibernate:hibernate-entitymanager</include>
           <include>org.hibernate:hibernate-core</include>
           <include>org.hibernate:hibernate-validator</include>
           <include>org.hibernate.common:hibernate-commons-annotations</include>
-          <include>com.sun.xml.bind:jaxb-impl</include>
           <include>com.sun.xml.bind:jaxb-xjc</include>
           <include>org.jboss.logging:jboss-logging</include>
           <include>org.slf4j:jcl-over-slf4j</include>
-          <include>org.jdom:jdom</include>
-          <include>joda-time:joda-time</include>
-          <include>org.apache.neethi:neethi</include>
           <include>org.slf4j:slf4j-api</include>
           <include>org.slf4j:slf4j-ext</include>
           <include>org.slf4j:slf4j-jdk14:jar</include>
-          <include>org.yaml:snakeyaml</include>
-          <include>org.apache.velocity:velocity</include>
           <include>org.codehaus.woodstox:woodstox-core-asl</include>
           <include>wsdl4j:wsdl4j</include>
           <include>xerces:xercesImpl</include>
-
-          <include>org.codehaus.jackson:*</include>
         </includes>
         <unpack>false</unpack>
         <outputDirectory>WEB-INF/lib</outputDirectory>
@@ -83,6 +69,10 @@
             <exclude>WEB-INF/lib/errai-jboss-as-support-*.jar</exclude>
             <!-- Errai 1.1+ CDI Compat -->
             <exclude>WEB-INF/lib/errai-weld-integration-*.jar</exclude>
+
+            <exclude>WEB-INF/lib/org.osgi.core-*.jar</exclude>
+            <exclude>WEB-INF/lib/javassist-*.jar</exclude>
+            <exclude>WEB-INF/lib/jgroups-*.jar</exclude>
           </excludes>
         </unpackOptions>
         <useStrictFiltering>true</useStrictFiltering>

--- a/kie-wb/kie-wb-distribution-wars/src/main/assembly/component-kie-wb-websphere-as-8-common.xml
+++ b/kie-wb/kie-wb-distribution-wars/src/main/assembly/component-kie-wb-websphere-as-8-common.xml
@@ -15,31 +15,20 @@
      <dependencySet>
        <includes>
          <include>antlr:antlr</include>
-         <include>commons-cli:commons-cli</include>
-         <include>commons-codec:commons-codec</include>
-         <include>commons-collections:commons-collections</include>
-         <include>commons-configuration:commons-configuration</include>
-         <include>commons-io:commons-io</include>
-         <include>commons-lang:commons-lang</include>
          <include>org.apache.cxf:*</include>
+         <include>org.apache.neethi:neethi</include>
          <include>dom4j:dom4j</include>
-         <include>org.apache.httpcomponents:httpclient</include>
          <include>org.hibernate:hibernate-entitymanager</include>
          <include>org.hibernate:hibernate-core</include>
          <include>org.hibernate:hibernate-validator</include>
          <include>org.hibernate.common:hibernate-commons-annotations</include>
-         <include>com.sun.xml.bind:jaxb-impl</include>
          <include>com.sun.xml.bind:jaxb-xjc</include>
          <include>org.jboss.logging:jboss-logging</include>
          <include>org.slf4j:jcl-over-slf4j</include>
-         <include>org.jdom:jdom</include>
-         <include>joda-time:joda-time</include>
-         <include>org.apache.neethi:neethi</include>
          <include>org.slf4j:slf4j-api</include>
          <include>org.slf4j:slf4j-ext</include>
          <include>org.slf4j:slf4j-jdk14:jar</include>
          <include>org.yaml:snakeyaml</include>
-         <include>org.apache.velocity:velocity</include>
          <include>org.codehaus.woodstox:woodstox-core-asl</include>
          <include>org.codehaus.woodstox:stax2-api</include>
          <include>wsdl4j:wsdl4j</include>
@@ -85,6 +74,11 @@
            <exclude>WEB-INF/lib/errai-jboss-as-support-*.jar</exclude>
            <!-- Errai 1.1+ CDI Compat -->
            <exclude>WEB-INF/lib/errai-weld-integration-*.jar</exclude>
+           <exclude>WEB-INF/lib/errai-weld-integration-*.jar</exclude>
+           <exclude>WEB-INF/lib/org.osgi.core-*.jar</exclude>
+           <exclude>WEB-INF/lib/javassist-*.jar</exclude>
+           <exclude>WEB-INF/lib/jgroups-*.jar</exclude>
+           <exclude>WEB-INF/lib/jackson-*.jar</exclude>
          </excludes>
        </unpackOptions>
        <useStrictFiltering>true</useStrictFiltering>

--- a/kie-wb/kie-wb-distribution-wars/src/main/assembly/eap6_4/WEB-INF/jboss-deployment-structure.xml
+++ b/kie-wb/kie-wb-distribution-wars/src/main/assembly/eap6_4/WEB-INF/jboss-deployment-structure.xml
@@ -20,71 +20,49 @@
 <jboss-deployment-structure xmlns="urn:jboss:deployment-structure:1.0">
   <deployment>
     <dependencies>
-      <module name="org.jboss.netty"/>
-      <!-- EAP alignement -->
+      <!-- IMPORTANT: when adding dependency (module) here, make sure it is a public one.
+           Do not add private modules as there is no guarantee they won't be changed or
+           removed in future. EAP also generates warning(s) during the deployment if
+           the WAR depends on private modules. -->
+      <!-- Keep the alphabetical order! -->
       <module name="javax.activation.api"/>
-      <module name="org.antlr"/>
-      <module name="org.apache.commons.cli"/>
-      <module name="org.apache.commons.collections"/>
-      <module name="org.apache.commons.lang"/>
-      <module name="org.apache.commons.codec"/>
-      <module name="org.apache.commons.io"/>
-      <module name="com.sun.xml.bind"/>
-      <module name="org.osgi.core"/>
-      <module name="org.yaml.snakeyaml"/>
-      <module name="org.apache.cxf.impl"/>
-      <module name="org.dom4j"/>
-      <module name="org.jboss.as.web"/>
-      <!-- this jar (ecj) is only in EAP 6.1, not in AS 7.1.1 -->
-      <module name="com.google.guava"/>
-      <module name="com.h2database.h2"/>
-      <module name="org.hibernate.commons-annotations"/>
-      <module name="org.hibernate"/>
-      <module name="javax.persistence.api"/>
-      <module name="org.hibernate.validator"/>
-      <module name="org.hornetq"/>
-      <module name="org.codehaus.jackson.jackson-core-asl"/>
-      <module name="org.codehaus.jackson.jackson-jaxrs"/>
-      <module name="org.codehaus.jackson.jackson-mapper-asl"/>
-      <module name="org.codehaus.jackson.jackson-xc"/>
-      <module name="org.javassist"/>
       <module name="javax.ejb.api"/>
-      <module name="org.slf4j.jcl-over-slf4j"/>
-      <module name="org.jdom"/>
-      <module name="org.codehaus.jettison"/>
-      <module name="org.joda.time"/>
       <module name="javax.faces.api"/>
-      <!-- check 1.2 -->
-      <module name="org.slf4j"/>
-      <module name="org.slf4j.ext"/>
-      <module name="org.apache.velocity"/>
-      <module name="org.codehaus.woodstox"/>
+      <module name="javax.jms.api"/>
+      <module name="javax.persistence.api"/>
+      <module name="javax.servlet.api"/>
+      <module name="javax.transaction.api"/>
+      <module name="javax.validation.api"/>
       <module name="javax.wsdl4j.api"/>
       <module name="org.apache.xalan"/>
       <module name="org.apache.xerces"/>
-
-      <!-- transitive dependencies -->
-      <module name="org.apache.james.mime4j"/>
-      <module name="org.apache.commons.configuration"/>
       <module name="org.apache.cxf"/>
-      <module name="org.apache.httpcomponents"/>
+      <module name="org.hibernate"/>
+      <module name="org.hibernate.commons-annotations"/>
+      <module name="org.hibernate.validator"/>
       <module name="org.jboss.ejb-client"/>
-      <module name="javax.jms.api"/>
       <module name="org.jboss.logging"/>
       <module name="org.jboss.logmanager"/>
       <module name="org.jboss.marshalling"/>
       <module name="org.jboss.remote-naming"/>
       <module name="org.jboss.remoting3"/>
-      <module name="org.jboss.sasl"/>
-      <module name="javax.servlet.api"/>
-      <module name="javax.transaction.api"/>
-      <module name="org.jgroups"/>
-      <module name="org.apache.neethi"/>
-      <module name="org.apache.xalan"/>
-      <module name="javax.validation.api"/>
-      <module name="org.apache.xml-resolver"/>
       <module name="org.jboss.xnio"/>
+      <module name="org.slf4j"/>
+      <module name="org.slf4j.ext"/>
+      <module name="org.slf4j.jcl-over-slf4j"/>
+
+      <!-- EXCEPTIONS - private modules that can not be directly added into the WEB-INF/lib -->
+      <!-- CXF is used both by kie-remote as framework for WS interface and by jbpm-workitems
+           to call remote WS endpoints. The jbpm-workitems artifact needs the actual CXF
+           implementation classes, not just the standard interfaces. Adding CXF impl classes
+           into the WEB-INF/lib directly would cause clashes as the EAP uses them as well. -->
+      <module name="org.apache.cxf.impl"/>
+      <!-- Dom4j is a transitive dependency of drools-decisiontables and needs to be on classpath.
+           It is also used by Hibernate and adding it directly into WEB-INF/lib results in
+           "org.dom4j.DocumentException: org.dom4j.DocumentFactory cannot be cast to org.dom4j.DocumentFactory"
+           Depending on the EAP module seems to be the only way.
+           See https://developer.jboss.org/thread/173306 for more info. -->
+      <module name="org.dom4j"/>
     </dependencies>
   </deployment>
 </jboss-deployment-structure>
-

--- a/kie-wb/kie-wb-webapp/pom.xml
+++ b/kie-wb/kie-wb-webapp/pom.xml
@@ -134,80 +134,11 @@
     </dependency>
 
     <dependency>
-      <groupId>commons-configuration</groupId>
-      <artifactId>commons-configuration</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>commons-collections</groupId>
-      <artifactId>commons-collections</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>commons-io</groupId>
-      <artifactId>commons-io</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>commons-lang</groupId>
-      <artifactId>commons-lang</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>commons-logging</groupId>
-      <artifactId>commons-logging</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>commons-codec</groupId>
-      <artifactId>commons-codec</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>commons-cli</groupId>
-      <artifactId>commons-cli</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>dom4j</groupId>
       <artifactId>dom4j</artifactId>
       <scope>provided</scope>
     </dependency>
-    <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-jaxrs</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-xc</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-core-asl</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-mapper-asl</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.javassist</groupId>
-      <artifactId>javassist</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jdom</groupId>
-      <artifactId>jdom</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.velocity</groupId>
-      <artifactId>velocity</artifactId>
-      <scope>provided</scope>
-    </dependency>
+
     <dependency>
       <groupId>xalan</groupId>
       <artifactId>xalan</artifactId>
@@ -221,27 +152,6 @@
     <dependency>
       <groupId>xerces</groupId>
       <artifactId>xercesImpl</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jgroups</groupId>
-      <artifactId>jgroups</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>joda-time</groupId>
-      <artifactId>joda-time</artifactId>
-      <scope>provided</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.yaml</groupId>
-      <artifactId>snakeyaml</artifactId>
       <scope>provided</scope>
     </dependency>
 
@@ -270,6 +180,10 @@
       <groupId>org.apache.abdera</groupId>
       <artifactId>abdera-core</artifactId>
       <exclusions>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
         <exclusion>
           <groupId>org.apache.geronimo.specs</groupId>
           <artifactId>geronimo-stax-api_1.0_spec</artifactId>
@@ -301,6 +215,12 @@
     <dependency>
       <groupId>org.kie</groupId>
       <artifactId>kie-ci</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!--Logs-->
@@ -315,18 +235,8 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>ch.qos.logback</groupId>
-      <artifactId>logback-core</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>jcl-over-slf4j</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
       <scope>provided</scope>
     </dependency>
 
@@ -943,6 +853,16 @@
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-ui</artifactId>
       <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jboss.errai</groupId>
@@ -987,25 +907,6 @@
       <artifactId>encoder</artifactId>
     </dependency>
 
-    <!-- Rogue imports to avoid OSGi errors -->
-    <dependency>
-      <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
-      <scope>provided</scope>
-    </dependency>
-
-    <!-- JAXB -->
-    <dependency>
-      <groupId>com.sun.xml.bind</groupId>
-      <artifactId>jaxb-impl</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.sun.xml.bind</groupId>
-      <artifactId>jaxb-xjc</artifactId>
-      <scope>provided</scope>
-    </dependency>
-
     <!-- jBPM Designer -->
     <dependency>
       <groupId>org.jbpm</groupId>
@@ -1031,12 +932,16 @@
       <artifactId>jbpm-designer-backend</artifactId>
       <exclusions>
         <exclusion>
-          <artifactId>slf4j-jdk14</artifactId>
-          <groupId>org.slf4j</groupId>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
         </exclusion>
         <exclusion>
-          <artifactId>log4j-over-slf4j</artifactId>
           <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-jdk14</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>log4j-over-slf4j</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -1124,6 +1029,12 @@
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-io</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.uberfire</groupId>
@@ -1324,6 +1235,16 @@
       <groupId>org.dashbuilder</groupId>
       <artifactId>dashbuilder-dataset-client</artifactId>
       <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-log4j12</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
@@ -1360,6 +1281,16 @@
       <groupId>org.dashbuilder</groupId>
       <artifactId>dashbuilder-widgets</artifactId>
       <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-log4j12</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/kie-wb/kie-wb-webapp/src/main/webapp/META-INF/MANIFEST.MF
+++ b/kie-wb/kie-wb-webapp/src/main/webapp/META-INF/MANIFEST.MF
@@ -1,1 +1,0 @@
-Dependencies: org.jboss.as.naming,org.jboss.as.server,org.jboss.msc

--- a/kie-wb/kie-wb-webapp/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/kie-wb/kie-wb-webapp/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -20,74 +20,49 @@
 <jboss-deployment-structure xmlns="urn:jboss:deployment-structure:1.0">
   <deployment>
     <dependencies>
-      <!-- We need org.jboss.netty not io.netty bundled with Wildfly -->
-      <!--<module name="io.netty" />-->
-
-      <!-- EAP alignement -->
+      <!-- IMPORTANT: when adding dependency (module) here, make sure it is a public one.
+           Do not add private modules as there is no guarantee they won't be changed or
+           removed in future. WildFly also generates warning(s) during the deployment if
+           the WAR depends on private modules. -->
+      <!-- Keep the alphabetical order! -->
       <module name="javax.activation.api"/>
-      <module name="org.antlr"/>
-      <module name="org.apache.commons.cli"/>
-      <module name="org.apache.commons.collections"/>
-      <module name="org.apache.commons.lang"/>
-      <module name="org.apache.commons.codec"/>
-      <module name="org.apache.commons.io"/>
-      <module name="com.sun.xml.bind"/>
-      <module name="org.osgi.core"/>
-      <module name="org.yaml.snakeyaml"/>
-      <module name="org.apache.cxf.impl"/>
-      <module name="org.dom4j"/>
-      <module name="org.jboss.as.web"/>
-      <!-- this jar (ecj) is only in EAP 6.1, not in AS 7.1.1 -->
-      <!-- Exclude com.google.guava:guava:16.0.1 provided by Wildfly as we need com.google.guava:guava:13.0.1 -->
-      <!--<module name="com.google.guava" />-->
-      <module name="com.h2database.h2"/>
-      <module name="org.hibernate.commons-annotations"/>
-      <module name="org.hibernate"/>
-      <module name="javax.persistence.api"/>
-      <module name="org.hibernate.validator"/>
-      <module name="org.hornetq"/>
-      <module name="org.codehaus.jackson.jackson-core-asl"/>
-      <module name="org.codehaus.jackson.jackson-jaxrs"/>
-      <module name="org.codehaus.jackson.jackson-mapper-asl"/>
-      <module name="org.codehaus.jackson.jackson-xc"/>
-      <module name="org.javassist"/>
       <module name="javax.ejb.api"/>
-      <module name="org.slf4j.jcl-over-slf4j"/>
-      <module name="org.jdom"/>
-      <module name="org.codehaus.jettison"/>
-      <module name="org.joda.time"/>
       <module name="javax.faces.api"/>
-      <!-- check 1.2 -->
-      <module name="org.slf4j"/>
-      <module name="org.slf4j.ext"/>
-      <module name="org.apache.velocity"/>
-      <module name="org.codehaus.woodstox"/>
+      <module name="javax.jms.api"/>
+      <module name="javax.persistence.api"/>
+      <module name="javax.servlet.api"/>
+      <module name="javax.transaction.api"/>
+      <module name="javax.validation.api"/>
       <module name="javax.wsdl4j.api"/>
       <module name="org.apache.xalan"/>
       <module name="org.apache.xerces"/>
-
-      <!-- transitive dependencies -->
-      <module name="org.apache.james.mime4j"/>
-      <module name="org.apache.commons.configuration"/>
       <module name="org.apache.cxf"/>
-      <module name="org.apache.httpcomponents"/>
+      <module name="org.hibernate"/>
+      <module name="org.hibernate.commons-annotations"/>
+      <module name="org.hibernate.validator"/>
       <module name="org.jboss.ejb-client"/>
-      <module name="javax.jms.api"/>
       <module name="org.jboss.logging"/>
       <module name="org.jboss.logmanager"/>
       <module name="org.jboss.marshalling"/>
       <module name="org.jboss.remote-naming"/>
       <module name="org.jboss.remoting3"/>
-      <module name="org.jboss.sasl"/>
-      <module name="javax.servlet.api"/>
-      <module name="javax.transaction.api"/>
-      <module name="org.jgroups"/>
-      <module name="org.apache.neethi"/>
-      <module name="org.apache.xalan"/>
-      <module name="javax.validation.api"/>
-      <module name="org.apache.xml-resolver"/>
       <module name="org.jboss.xnio"/>
+      <module name="org.slf4j"/>
+      <module name="org.slf4j.ext"/>
+      <module name="org.slf4j.jcl-over-slf4j"/>
+
+      <!-- EXCEPTIONS - private/unsupported modules that can not be directly added into the WEB-INF/lib -->
+      <!-- CXF is used both by kie-remote as framework for WS interface and by jbpm-workitems
+           to call remote WS endpoints. The jbpm-workitems artifact needs the actual CXF
+           implementation classes, not just the standard interfaces. Adding CXF impl classes
+           into the WEB-INF/lib directly would cause clashes as the EAP uses them as well. -->
+      <module name="org.apache.cxf.impl"/>
+      <!-- Dom4j is a transitive dependency of drools-decisiontables and needs to be on classpath.
+           It is also used by Hibernate and adding it directly into WEB-INF/lib results in
+           "org.dom4j.DocumentException: org.dom4j.DocumentFactory cannot be cast to org.dom4j.DocumentFactory"
+           Depending on the EAP module seems to be the only way.
+           See https://developer.jboss.org/thread/173306 for more info. -->
+      <module name="org.dom4j"/>
     </dependencies>
   </deployment>
 </jboss-deployment-structure>
-


### PR DESCRIPTION
 * removed the private/unsupported modules from jboss-deployment-structure.xml
   (as logged by WildFly and EAP during deployment)
 * jars from the private modules need to be directly in WEB-INF/lib
 * updated the other assemblies (includes/excludes) to reflect these changes
 * EAP/WildFly distros few additional jars in WEB-INF/lib
 * Tomcat/WAS/WLS distros are exactly the same as before
   (even though the assemblies changed)
 * there are two exceptions: dom4j and CXF. See the comments in the
   jboss-deployment-structure.xml files for more details.

@manstis @porcelli @mswiderski please take a look and let me know what you think.