### PR TITLE
Override Errai DEBUG logging using own logback.xml config

### DIFF
--- a/kie-drools-wb/kie-drools-wb-webapp/pom.xml
+++ b/kie-drools-wb/kie-drools-wb-webapp/pom.xml
@@ -1533,7 +1533,12 @@
       <plugin>
         <artifactId>maven-war-plugin</artifactId>
         <configuration>
-          <packagingExcludes>**/javax/**/*.*,**/client/**/*.class,**/*.symbolMap</packagingExcludes>
+          <packagingExcludes>
+            **/javax/**/*.*,
+            **/client/**/*.class,
+            **/*.symbolMap,
+            WEB-INF/classes/logback.xml
+          </packagingExcludes>
           <archive>
             <addMavenDescriptor>false</addMavenDescriptor>
           </archive>

--- a/kie-drools-wb/kie-drools-wb-webapp/src/main/resources/logback.xml
+++ b/kie-drools-wb/kie-drools-wb-webapp/src/main/resources/logback.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="info">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>

--- a/kie-wb/kie-wb-webapp/pom.xml
+++ b/kie-wb/kie-wb-webapp/pom.xml
@@ -1781,7 +1781,12 @@
       <plugin>
         <artifactId>maven-war-plugin</artifactId>
         <configuration>
-          <packagingExcludes>**/javax/**/*.*,**/client/**/*.class,**/*.symbolMap</packagingExcludes>
+          <packagingExcludes>
+            **/javax/**/*.*,
+            **/client/**/*.class,
+            **/*.symbolMap,
+            WEB-INF/classes/logback.xml
+          </packagingExcludes>
           <archive>
             <addMavenDescriptor>false</addMavenDescriptor>
           </archive>

--- a/kie-wb/kie-wb-webapp/src/main/resources/logback.xml
+++ b/kie-wb/kie-wb-webapp/src/main/resources/logback.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="info">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>


### PR DESCRIPTION
 * the root level is set to info, so only info messages
   will be printed

 * the logback.xml is also excluded from the final WAR
   as it should not be there (it would then need to be
   removed in the distribution-wars assemblies)

* as discusses with @csadilek this should be the best
  way of suppressing long Errai DEBUG output during
  gwt:compile