### PR TITLE
Remove CXF deps from KIE Drools WB as they are not needed

### DIFF
--- a/kie-drools-wb/kie-drools-wb-distribution-wars/pom.xml
+++ b/kie-drools-wb/kie-drools-wb-distribution-wars/pom.xml
@@ -169,46 +169,6 @@
       <artifactId>antlr</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.cxf</groupId>
-      <artifactId>cxf-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.cxf</groupId>
-      <artifactId>cxf-rt-bindings-soap</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.cxf</groupId>
-      <artifactId>cxf-rt-bindings-xml</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.cxf</groupId>
-      <artifactId>cxf-rt-core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.cxf</groupId>
-      <artifactId>cxf-rt-databinding-jaxb</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.cxf</groupId>
-      <artifactId>cxf-rt-frontend-jaxws</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.cxf</groupId>
-      <artifactId>cxf-rt-frontend-simple</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.cxf</groupId>
-      <artifactId>cxf-rt-transports-http</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.cxf</groupId>
-      <artifactId>cxf-rt-ws-addr</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.cxf</groupId>
-      <artifactId>cxf-rt-ws-policy</artifactId>
-    </dependency>
-    <dependency>
       <groupId>dom4j</groupId>
       <artifactId>dom4j</artifactId>
     </dependency>

--- a/kie-drools-wb/kie-drools-wb-distribution-wars/src/main/assembly/component-kie-drools-wb-tomcat-7-common.xml
+++ b/kie-drools-wb/kie-drools-wb-distribution-wars/src/main/assembly/component-kie-drools-wb-tomcat-7-common.xml
@@ -12,7 +12,6 @@
       <includes>
         <include>antlr:antlr</include>
         <include>dom4j:dom4j</include>
-        <include>org.apache.cxf:*</include>
         <include>org.apache.neethi:neethi</include>
         <include>org.hibernate.javax.persistence:hibernate-jpa-2.0-api</include>
         <include>org.hibernate:hibernate-entitymanager</include>

--- a/kie-drools-wb/kie-drools-wb-distribution-wars/src/main/assembly/component-kie-drools-wb-weblogic-12-common.xml
+++ b/kie-drools-wb/kie-drools-wb-distribution-wars/src/main/assembly/component-kie-drools-wb-weblogic-12-common.xml
@@ -16,7 +16,6 @@
       <includes>
         <include>antlr:antlr</include>
         <include>dom4j:dom4j</include>
-        <include>org.apache.cxf:*</include>
         <include>org.apache.neethi:neethi</include>
         <include>org.codehaus.jackson:jackson-jaxrs</include>
         <include>org.codehaus.woodstox:woodstox-core-asl</include>

--- a/kie-drools-wb/kie-drools-wb-distribution-wars/src/main/assembly/component-kie-drools-wb-websphere-as-8-common.xml
+++ b/kie-drools-wb/kie-drools-wb-distribution-wars/src/main/assembly/component-kie-drools-wb-websphere-as-8-common.xml
@@ -16,7 +16,6 @@
       <includes>
         <include>antlr:antlr</include>
         <include>dom4j:dom4j</include>
-        <include>org.apache.cxf:*</include>
         <include>org.apache.neethi:neethi</include>
         <include>org.hibernate:hibernate-entitymanager</include>
         <include>org.hibernate:hibernate-core</include>


### PR DESCRIPTION
As discusses with @mswiderski last week, the CXF should not be needed for KIE Drools WB. This commit removes it from the distribution wars.