### PR TITLE
[DROOLS-797] use different classifier for productized builds

### DIFF
--- a/kie-drools-wb/kie-drools-wb-distribution-wars/pom.xml
+++ b/kie-drools-wb/kie-drools-wb-distribution-wars/pom.xml
@@ -27,12 +27,6 @@
   </dependencyManagement>
 
   <dependencies>
-    <!-- Internal dependencies -->
-    <dependency>
-      <groupId>org.kie</groupId>
-      <artifactId>kie-drools-wb-webapp</artifactId>
-      <type>war</type>
-    </dependency>
 
     <!-- External dependencies -->
     <!--tomcat-->
@@ -337,6 +331,28 @@
 
   <profiles>
     <profile>
+      <id>notProductizedProfile</id>
+      <activation>
+        <property>
+          <name>!productized</name>
+        </property>
+      </activation>
+
+      <properties>
+        <webapp.war>org.kie:kie-drools-wb-webapp:war</webapp.war>
+      </properties>
+
+      <dependencies>
+        <dependency>
+          <groupId>org.kie</groupId>
+          <artifactId>kie-drools-wb-webapp</artifactId>
+          <type>war</type>
+        </dependency>
+      </dependencies>
+
+    </profile>
+
+    <profile>
       <id>productizedProfile</id>
 
       <activation>
@@ -344,6 +360,31 @@
           <name>productized</name>
         </property>
       </activation>
+
+      <properties>
+        <webapp.war>org.kie:kie-drools-wb-webapp:war:redhat</webapp.war>
+      </properties>
+
+      <dependencyManagement>
+        <dependencies>
+          <dependency>
+            <groupId>org.kie</groupId>
+            <artifactId>kie-drools-wb-webapp</artifactId>
+            <version>${version.org.kie}</version>
+            <type>war</type>
+            <classifier>redhat</classifier>
+          </dependency>
+        </dependencies>
+      </dependencyManagement>
+
+      <dependencies>
+        <dependency>
+          <groupId>org.kie</groupId>
+          <artifactId>kie-drools-wb-webapp</artifactId>
+          <type>war</type>
+          <classifier>redhat</classifier>
+        </dependency>
+      </dependencies>
 
       <build>
         <plugins>

--- a/kie-drools-wb/kie-drools-wb-distribution-wars/src/main/assembly/component-kie-drools-wb-eap-6_4-common.xml
+++ b/kie-drools-wb/kie-drools-wb-distribution-wars/src/main/assembly/component-kie-drools-wb-eap-6_4-common.xml
@@ -10,7 +10,7 @@
   <dependencySets>
     <dependencySet>
       <includes>
-        <include>org.kie:kie-drools-wb-webapp:war</include>
+        <include>${webapp.war}</include>
       </includes>
       <outputDirectory>.</outputDirectory>
       <unpack>true</unpack>

--- a/kie-drools-wb/kie-drools-wb-distribution-wars/src/main/assembly/component-kie-drools-wb-tomcat-7-common.xml
+++ b/kie-drools-wb/kie-drools-wb-distribution-wars/src/main/assembly/component-kie-drools-wb-tomcat-7-common.xml
@@ -68,7 +68,7 @@
     </dependencySet>
     <dependencySet>
       <includes>
-        <include>org.kie:kie-drools-wb-webapp:war</include>
+        <include>${webapp.war}</include>
       </includes>
       <outputDirectory>.</outputDirectory>
       <unpack>true</unpack>

--- a/kie-drools-wb/kie-drools-wb-distribution-wars/src/main/assembly/component-kie-drools-wb-weblogic-12-common.xml
+++ b/kie-drools-wb/kie-drools-wb-distribution-wars/src/main/assembly/component-kie-drools-wb-weblogic-12-common.xml
@@ -37,7 +37,7 @@
     </dependencySet>
     <dependencySet>
       <includes>
-        <include>org.kie:kie-drools-wb-webapp:war</include>
+        <include>${webapp.war}</include>
       </includes>
       <outputDirectory>.</outputDirectory>
       <unpack>true</unpack>

--- a/kie-drools-wb/kie-drools-wb-distribution-wars/src/main/assembly/component-kie-drools-wb-websphere-as-8-common.xml
+++ b/kie-drools-wb/kie-drools-wb-distribution-wars/src/main/assembly/component-kie-drools-wb-websphere-as-8-common.xml
@@ -38,7 +38,7 @@
     </dependencySet>
     <dependencySet>
       <includes>
-        <include>org.kie:kie-drools-wb-webapp:war</include>
+        <include>${webapp.war}</include>
       </includes>
       <outputDirectory>.</outputDirectory>
       <unpack>true</unpack>

--- a/kie-drools-wb/kie-drools-wb-distribution-wars/src/main/productized/assembly-kie-drools-wb-jboss-eap-6_4-redhat.xml
+++ b/kie-drools-wb/kie-drools-wb-distribution-wars/src/main/productized/assembly-kie-drools-wb-jboss-eap-6_4-redhat.xml
@@ -20,7 +20,7 @@
           xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
 
   <!-- including a . in the id will modify the *classifier* of the artifact, instead of the name/id of the artifact -->
-  <id>eap6_4</id>
+  <id>eap6_4-redhat</id>
   <formats>
     <format>war</format>
     <format>dir</format>

--- a/kie-drools-wb/kie-drools-wb-distribution-wars/src/main/productized/assembly-kie-drools-wb-tomcat-7-redhat.xml
+++ b/kie-drools-wb/kie-drools-wb-distribution-wars/src/main/productized/assembly-kie-drools-wb-tomcat-7-redhat.xml
@@ -3,7 +3,7 @@
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
 
-  <id>tomcat7</id>
+  <id>tomcat7-redhat</id>
   <formats>
     <format>war</format>
     <format>dir</format>

--- a/kie-drools-wb/kie-drools-wb-distribution-wars/src/main/productized/assembly-kie-drools-wb-weblogic-12-redhat.xml
+++ b/kie-drools-wb/kie-drools-wb-distribution-wars/src/main/productized/assembly-kie-drools-wb-weblogic-12-redhat.xml
@@ -20,7 +20,7 @@
           xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
 
   <!-- including a . in the id will modify the *classifier* of the artifact, instead of the name/id of the artifact -->
-  <id>weblogic12</id>
+  <id>weblogic12-redhat</id>
   <formats>
     <format>war</format>
     <format>dir</format>

--- a/kie-drools-wb/kie-drools-wb-distribution-wars/src/main/productized/assembly-kie-drools-wb-websphere-as-8-redhat.xml
+++ b/kie-drools-wb/kie-drools-wb-distribution-wars/src/main/productized/assembly-kie-drools-wb-websphere-as-8-redhat.xml
@@ -19,7 +19,7 @@
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
 
-  <id>was8</id>
+  <id>was8-redhat</id>
   <formats>
     <format>war</format>
     <format>dir</format>

--- a/kie-drools-wb/kie-drools-wb-webapp/pom.xml
+++ b/kie-drools-wb/kie-drools-wb-webapp/pom.xml
@@ -1611,6 +1611,16 @@
                 </compileSourcesArtifacts>
               </configuration>
             </plugin>
+            <!-- Use different classifier for "-Dproductized" builds, to be able
+                 to clearly differentiate between community and productized build
+                 (they will have different classifier). -->
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-war-plugin</artifactId>
+              <configuration>
+                <classifier>redhat</classifier>
+              </configuration>
+            </plugin>
           </plugins>
         </pluginManagement>
       </build>

--- a/kie-wb/kie-wb-distribution-wars/pom.xml
+++ b/kie-wb/kie-wb-distribution-wars/pom.xml
@@ -395,6 +395,28 @@
 
   <profiles>
     <profile>
+      <id>notProductizedProfile</id>
+      <activation>
+        <property>
+          <name>!productized</name>
+        </property>
+      </activation>
+
+      <properties>
+        <webapp.war>org.kie:kie-wb-webapp:war</webapp.war>
+      </properties>
+
+      <dependencies>
+        <dependency>
+          <groupId>org.kie</groupId>
+          <artifactId>kie-wb-webapp</artifactId>
+          <type>war</type>
+        </dependency>
+      </dependencies>
+
+    </profile>
+
+    <profile>
       <id>productizedProfile</id>
 
       <activation>
@@ -402,6 +424,31 @@
           <name>productized</name>
         </property>
       </activation>
+
+      <properties>
+        <webapp.war>org.kie:kie-wb-webapp:war:redhat</webapp.war>
+      </properties>
+
+      <dependencyManagement>
+        <dependencies>
+          <dependency>
+            <groupId>org.kie</groupId>
+            <artifactId>kie-wb-webapp</artifactId>
+            <version>${version.org.kie}</version>
+            <type>war</type>
+            <classifier>redhat</classifier>
+          </dependency>
+        </dependencies>
+      </dependencyManagement>
+
+      <dependencies>
+        <dependency>
+          <groupId>org.kie</groupId>
+          <artifactId>kie-wb-webapp</artifactId>
+          <type>war</type>
+          <classifier>redhat</classifier>
+        </dependency>
+      </dependencies>
 
       <build>
         <plugins>

--- a/kie-wb/kie-wb-distribution-wars/src/main/assembly/component-kie-wb-eap-6_4-common.xml
+++ b/kie-wb/kie-wb-distribution-wars/src/main/assembly/component-kie-wb-eap-6_4-common.xml
@@ -10,7 +10,7 @@
     <dependencySets>
       <dependencySet>
         <includes>
-          <include>org.kie:kie-wb-webapp:war</include>
+          <include>${webapp.war}</include>
         </includes>
         <outputDirectory>.</outputDirectory>
         <unpack>true</unpack>

--- a/kie-wb/kie-wb-distribution-wars/src/main/assembly/component-kie-wb-tomcat-7-common.xml
+++ b/kie-wb/kie-wb-distribution-wars/src/main/assembly/component-kie-wb-tomcat-7-common.xml
@@ -68,7 +68,7 @@
       </dependencySet>
       <dependencySet>
         <includes>
-          <include>org.kie:kie-wb-webapp:war</include>
+          <include>${webapp.war}</include>
         </includes>
         <outputDirectory>.</outputDirectory>
         <unpack>true</unpack>

--- a/kie-wb/kie-wb-distribution-wars/src/main/assembly/component-kie-wb-weblogic-12-common.xml
+++ b/kie-wb/kie-wb-distribution-wars/src/main/assembly/component-kie-wb-weblogic-12-common.xml
@@ -37,7 +37,7 @@
       </dependencySet>
       <dependencySet>
         <includes>
-          <include>org.kie:kie-wb-webapp:war</include>
+          <include>${webapp.war}</include>
         </includes>
         <outputDirectory>.</outputDirectory>
         <unpack>true</unpack>

--- a/kie-wb/kie-wb-distribution-wars/src/main/assembly/component-kie-wb-websphere-as-8-common.xml
+++ b/kie-wb/kie-wb-distribution-wars/src/main/assembly/component-kie-wb-websphere-as-8-common.xml
@@ -40,7 +40,7 @@
      </dependencySet>
      <dependencySet>
        <includes>
-         <include>org.kie:kie-wb-webapp:war</include>
+         <include>${webapp.war}</include>
        </includes>
        <outputDirectory>.</outputDirectory>
        <unpack>true</unpack>

--- a/kie-wb/kie-wb-distribution-wars/src/main/productized/assembly-kie-wb-jboss-eap-6_4-redhat.xml
+++ b/kie-wb/kie-wb-distribution-wars/src/main/productized/assembly-kie-wb-jboss-eap-6_4-redhat.xml
@@ -20,7 +20,7 @@
           xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
 
   <!-- including a . in the id will modify the *classifier* of the artifact, instead of the name/id of the artifact -->
-  <id>eap6_4</id>
+  <id>eap6_4-redhat</id>
   <formats>
     <format>war</format>
     <format>dir</format>

--- a/kie-wb/kie-wb-distribution-wars/src/main/productized/assembly-kie-wb-tomcat-7-redhat.xml
+++ b/kie-wb/kie-wb-distribution-wars/src/main/productized/assembly-kie-wb-tomcat-7-redhat.xml
@@ -4,7 +4,7 @@
           xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
 
   <!-- including a . in the id will modify the *classifier* of the artifact, instead of the name of the artifact -->
-  <id>tomcat7</id>
+  <id>tomcat7-redhat</id>
   <formats>
     <format>war</format>
     <format>dir</format>

--- a/kie-wb/kie-wb-distribution-wars/src/main/productized/assembly-kie-wb-weblogic-12-redhat.xml
+++ b/kie-wb/kie-wb-distribution-wars/src/main/productized/assembly-kie-wb-weblogic-12-redhat.xml
@@ -4,7 +4,7 @@
           xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
 
   <!-- including a . in the id will modify the *classifier* of the artifact, instead of the name of the artifact -->
-  <id>weblogic12</id>
+  <id>weblogic12-redhat</id>
   <formats>
     <format>war</format>
     <format>dir</format>

--- a/kie-wb/kie-wb-distribution-wars/src/main/productized/assembly-kie-wb-websphere-as-8-redhat.xml
+++ b/kie-wb/kie-wb-distribution-wars/src/main/productized/assembly-kie-wb-websphere-as-8-redhat.xml
@@ -20,7 +20,7 @@
           xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
 
   <!-- including a . in the id will modify the *classifier* of the artifact, instead of the name/id of the artifact -->
-  <id>was8</id>
+  <id>was8-redhat</id>
   <formats>
     <format>war</format>
     <format>dir</format>

--- a/kie-wb/kie-wb-webapp/pom.xml
+++ b/kie-wb/kie-wb-webapp/pom.xml
@@ -1895,6 +1895,16 @@
                 </compileSourcesArtifacts>
               </configuration>
             </plugin>
+            <!-- Use different classifier for "-Dproductized" builds, to be able
+                 to clearly differentiate between community and productized build
+                 (they will have different classifier). -->
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-war-plugin</artifactId>
+              <configuration>
+                <classifier>redhat</classifier>
+              </configuration>
+            </plugin>
           </plugins>
         </pluginManagement>
       </build>


### PR DESCRIPTION
 * this way we can have both variants in same repo as Maven
   itself can differentiate between them using the classifier

@ryanzhang can you please take a look and let me know if this change somehow make you life harder? Basically all you need to change on your side are the artifact coordinates -- e.g. adding the new classifier.