### PR TITLE
Remove 'x-ua-compatible' meta-data

### DIFF
--- a/kie-drools-wb/kie-drools-wb-distribution-wars/src/main/productized/webapp/kie-drools-wb.html
+++ b/kie-drools-wb/kie-drools-wb-distribution-wars/src/main/productized/webapp/kie-drools-wb.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta http-equiv="x-ua-compatible" content="IE=10">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="-1">
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <meta name="gwt:property" content="locale=@{locale}">
 

--- a/kie-drools-wb/kie-drools-wb-webapp/src/main/webapp/kie-drools-wb.html
+++ b/kie-drools-wb/kie-drools-wb-webapp/src/main/webapp/kie-drools-wb.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta http-equiv="x-ua-compatible" content="IE=10">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="-1">
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <meta name="gwt:property" content="locale=@{locale}">
 

--- a/kie-wb/kie-wb-distribution-wars/src/main/productized/webapp/kie-wb.html
+++ b/kie-wb/kie-wb-distribution-wars/src/main/productized/webapp/kie-wb.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta http-equiv="x-ua-compatible" content="IE=10">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="-1">
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <meta name="gwt:property" content="locale=@{locale}">
 

--- a/kie-wb/kie-wb-webapp/src/main/webapp/kie-wb.html
+++ b/kie-wb/kie-wb-webapp/src/main/webapp/kie-wb.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta http-equiv="x-ua-compatible" content="IE=10">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="-1">
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <meta name="gwt:property" content="locale=@{locale}">
 


### PR DESCRIPTION
Remove 'x-ua-compatible' meta-data since (1) kie-(drools)-wb 6.3.0-SNAPSHOT doesn't run on IE11, (2) we've moved to GWT2.7 that supports IE11

See https://github.com/droolsjbpm/kie-wb-distributions/commit/bf6ab29d174b5c4d49b8d9512c75885190743d78

I also added meta-data tags to prevent caching of the host-page; that are inserted by the GWT2.7 Archetype.. so thought it prudent to use them too.