### PR TITLE
Exclude org.uberfire.backend.server.LockClientNotifier that was causing system.git to be initialized ahead of kie-config-cli expecting it to be available.

### DIFF
--- a/kie-config-cli/src/main/resources/META-INF/beans.xml
+++ b/kie-config-cli/src/main/resources/META-INF/beans.xml
@@ -8,6 +8,7 @@
   <weld:scan>
     <weld:exclude name="org.jbpm.kie.services.impl.form.FormProviderServiceImpl"/>
     <weld:exclude name="org.guvnor.structure.backend.repositories.git.GitRepositoryFactoryHelper"/>
+    <weld:exclude name="org.uberfire.backend.server.LockClientNotifier"/>
   </weld:scan>
 
   <alternatives>


### PR DESCRIPTION
Hi Christian,

I noticed ```LockClientNotifier``` was setting up an instance of ```system.git``` (to hold the locks) ahead of when ```kie-config-cli``` was expecting it to be available. This lead to failure of the CLI tool to push the (```LockClientNotifier``` created) ```system.git``` to ```remote/origin``` before User's credentials had been configured on the FS (```LockClientNotifier``` registers ```system.git``` as "guest" whereas ```kie-config-cli``` needs ```system.git``` to be registered as a "real" user). 

Simple PR.. wordy explanation...