### PR TITLE
BPMSPL-156: Process dashboard refactor

### DIFF
--- a/kie-wb/kie-wb-webapp/src/main/java/org/kie/workbench/backend/DashbuilderBootstrap.java
+++ b/kie-wb/kie-wb-webapp/src/main/java/org/kie/workbench/backend/DashbuilderBootstrap.java
@@ -24,6 +24,7 @@ import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 
 import org.dashbuilder.dataset.DataSetFactory;
+import org.dashbuilder.dataset.def.DataSetDef;
 import org.dashbuilder.dataset.def.DataSetDefRegistry;
 import org.jbpm.console.ng.es.client.editors.requestlist.RequestListViewImpl;
 import org.jbpm.console.ng.ht.client.editors.taskslist.grid.dash.DataSetTasksListGridViewImpl;
@@ -52,6 +53,9 @@ public class DashbuilderBootstrap {
     public static final String REQUEST_LIST_TABLE = "RequestInfo";
 
     public static final String  PROCESS_INSTANCE_WITH_VARIABLES_DATASET = "jbpmProcessInstancesWithVariables";
+
+    public static final String TASKS_MONITORING_DATASET = "tasksMonitoring";
+    public static final String PROCESSES_MONITORING_DATASET = "processesMonitoring";
 
     @Inject
     protected DataSetDefRegistry dataSetDefRegistry;
@@ -206,7 +210,30 @@ public class DashbuilderBootstrap {
                                 .label( "varname" )
                                 .label( "varvalue" )
                                 .buildDef() );
-    }
+
+        // Process && Task dashboard related
+
+        DataSetDef processMonitoringDef = DataSetFactory.newSQLDataSetDef()
+                .uuid(PROCESSES_MONITORING_DATASET)
+                .name("Processes monitoring")
+                .dataSource(jbpmDatasource)
+                .dbTable(PROCESS_INSTANCE_TABLE, true)
+                .buildDef();
+
+        DataSetDef taskMonitoringDef = DataSetFactory.newSQLDataSetDef()
+                .uuid(TASKS_MONITORING_DATASET)
+                .name("Tasks monitoring")
+                .dataSource(jbpmDatasource)
+                .dbSQL("select p.processname, t.* " +
+                        "from processinstancelog p inner join bamtasksummary t " +
+                        "on (t.processinstanceid = p.processinstanceid)", true)
+                .buildDef();
+
+        processMonitoringDef.setPublic(false);
+        taskMonitoringDef.setPublic(false);
+
+        dataSetDefRegistry.registerDataSetDef(processMonitoringDef);
+        dataSetDefRegistry.registerDataSetDef(taskMonitoringDef);}
 
     protected void findDataSourceJNDI() {
         try {


### PR DESCRIPTION
The older process dashboard iframe (based on the external dashbuilder webapp) has been entirely replaced by an Uberfire native perspective built on top of the UF dashbuilder module. The new process dashboard feeds from two non-public (hidden to end users) data sets (see taskMonitoring & processMonitoring data set registration in DashbuilderBootstrap).

This new process dashboard also includes the following feature:

https://issues.jboss.org/browse/BPMSPL-17

... which allows the user to list the related instances shown in the dashboard as well as the ability to open a details screen for every process or task instance selected.