### PR TITLE
JBPM-4748 - Modify the DynamicJaxbContextFilter to retrieve the deplo…

### DIFF
--- a/kie-wb/kie-wb-distribution-wars/src/main/assembly/eap6_4/WEB-INF/web-exec-server.xml
+++ b/kie-wb/kie-wb-distribution-wars/src/main/assembly/eap6_4/WEB-INF/web-exec-server.xml
@@ -160,7 +160,12 @@ Their default values are shown as example param-values -->
   </filter>
   <filter-mapping>
     <filter-name>Dynamic JAXBContext Filter</filter-name>
-    <url-pattern>/rest/*</url-pattern>
+    <url-pattern>/rest/deployment/*</url-pattern>
+    <url-pattern>/rest/history*</url-pattern>
+    <url-pattern>/rest/task/*</url-pattern>
+    <url-pattern>/rest/runtime/*</url-pattern>
+    <url-pattern>/rest/query/*</url-pattern>
+    <url-pattern>/rest/execute/*</url-pattern>
   </filter-mapping>
 
   <!-- web services -->

--- a/kie-wb/kie-wb-distribution-wars/src/main/assembly/tomcat7/WEB-INF/web-exec-server.xml
+++ b/kie-wb/kie-wb-distribution-wars/src/main/assembly/tomcat7/WEB-INF/web-exec-server.xml
@@ -200,7 +200,12 @@
   </filter>
   <filter-mapping>
     <filter-name>Dynamic JAXBContext Filter</filter-name>
-    <url-pattern>/rest/*</url-pattern>
+    <url-pattern>/rest/deployment/*</url-pattern>
+    <url-pattern>/rest/history*</url-pattern>
+    <url-pattern>/rest/task/*</url-pattern>
+    <url-pattern>/rest/runtime/*</url-pattern>
+    <url-pattern>/rest/query/*</url-pattern>
+    <url-pattern>/rest/execute/*</url-pattern>
   </filter-mapping>
 
   <!-- web services -->

--- a/kie-wb/kie-wb-distribution-wars/src/main/assembly/tomcat7/WEB-INF/web.xml
+++ b/kie-wb/kie-wb-distribution-wars/src/main/assembly/tomcat7/WEB-INF/web.xml
@@ -742,7 +742,12 @@ See http://www.w3.org/TR/SVG/intro.html#MIMEType. -->
   </filter>
   <filter-mapping>
     <filter-name>Dynamic JAXBContext Filter</filter-name>
-    <url-pattern>/rest/*</url-pattern>
+    <url-pattern>/rest/deployment/*</url-pattern>
+    <url-pattern>/rest/history*</url-pattern>
+    <url-pattern>/rest/task/*</url-pattern>
+    <url-pattern>/rest/runtime/*</url-pattern>
+    <url-pattern>/rest/query/*</url-pattern>
+    <url-pattern>/rest/execute/*</url-pattern>
     <url-pattern>/ws/*</url-pattern>
   </filter-mapping>
 

--- a/kie-wb/kie-wb-distribution-wars/src/main/assembly/was8/WEB-INF/web-exec-server.xml
+++ b/kie-wb/kie-wb-distribution-wars/src/main/assembly/was8/WEB-INF/web-exec-server.xml
@@ -136,7 +136,12 @@
   </filter>
   <filter-mapping>
     <filter-name>Dynamic JAXBContext Filter</filter-name>
-    <url-pattern>/rest/*</url-pattern>
+    <url-pattern>/rest/deployment/*</url-pattern>
+    <url-pattern>/rest/history*</url-pattern>
+    <url-pattern>/rest/task/*</url-pattern>
+    <url-pattern>/rest/runtime/*</url-pattern>
+    <url-pattern>/rest/query/*</url-pattern>
+    <url-pattern>/rest/execute/*</url-pattern>
   </filter-mapping>
 
   <!-- web services -->

--- a/kie-wb/kie-wb-distribution-wars/src/main/assembly/was8/WEB-INF/web.xml
+++ b/kie-wb/kie-wb-distribution-wars/src/main/assembly/was8/WEB-INF/web.xml
@@ -687,7 +687,12 @@ See http://www.w3.org/TR/SVG/intro.html#MIMEType. -->
   </filter>
   <filter-mapping>
     <filter-name>Dynamic JAXBContext Filter</filter-name>
-    <url-pattern>/rest/*</url-pattern>
+    <url-pattern>/rest/deployment/*</url-pattern>
+    <url-pattern>/rest/history*</url-pattern>
+    <url-pattern>/rest/task/*</url-pattern>
+    <url-pattern>/rest/runtime/*</url-pattern>
+    <url-pattern>/rest/query/*</url-pattern>
+    <url-pattern>/rest/execute/*</url-pattern>
     <url-pattern>/ws/*</url-pattern>
   </filter-mapping>
 

--- a/kie-wb/kie-wb-distribution-wars/src/main/assembly/weblogic12/WEB-INF/web-exec-server.xml
+++ b/kie-wb/kie-wb-distribution-wars/src/main/assembly/weblogic12/WEB-INF/web-exec-server.xml
@@ -139,7 +139,12 @@
   </filter>
   <filter-mapping>
     <filter-name>Dynamic JAXBContext Filter</filter-name>
-    <url-pattern>/rest/*</url-pattern>
+    <url-pattern>/rest/deployment/*</url-pattern>
+    <url-pattern>/rest/history*</url-pattern>
+    <url-pattern>/rest/task/*</url-pattern>
+    <url-pattern>/rest/runtime/*</url-pattern>
+    <url-pattern>/rest/query/*</url-pattern>
+    <url-pattern>/rest/execute/*</url-pattern>
   </filter-mapping>
 
   <!-- web services -->

--- a/kie-wb/kie-wb-distribution-wars/src/main/assembly/weblogic12/WEB-INF/web.xml
+++ b/kie-wb/kie-wb-distribution-wars/src/main/assembly/weblogic12/WEB-INF/web.xml
@@ -700,7 +700,12 @@ See http://www.w3.org/TR/SVG/intro.html#MIMEType. -->
   </filter>
   <filter-mapping>
     <filter-name>Dynamic JAXBContext Filter</filter-name>
-    <url-pattern>/rest/*</url-pattern>
+    <url-pattern>/rest/deployment/*</url-pattern>
+    <url-pattern>/rest/history*</url-pattern>
+    <url-pattern>/rest/task/*</url-pattern>
+    <url-pattern>/rest/runtime/*</url-pattern>
+    <url-pattern>/rest/query/*</url-pattern>
+    <url-pattern>/rest/execute/*</url-pattern>
     <url-pattern>/ws/*</url-pattern>
   </filter-mapping>
 

--- a/kie-wb/kie-wb-distribution-wars/src/main/assembly/wildfly8/WEB-INF/web-exec-server.xml
+++ b/kie-wb/kie-wb-distribution-wars/src/main/assembly/wildfly8/WEB-INF/web-exec-server.xml
@@ -161,7 +161,12 @@ Their default values are shown as example param-values -->
   </filter>
   <filter-mapping>
     <filter-name>Dynamic JAXBContext Filter</filter-name>
-    <url-pattern>/rest/*</url-pattern>
+    <url-pattern>/rest/deployment/*</url-pattern>
+    <url-pattern>/rest/history*</url-pattern>
+    <url-pattern>/rest/task/*</url-pattern>
+    <url-pattern>/rest/runtime/*</url-pattern>
+    <url-pattern>/rest/query/*</url-pattern>
+    <url-pattern>/rest/execute/*</url-pattern>
   </filter-mapping>
 
   <!-- web services -->

--- a/kie-wb/kie-wb-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/kie-wb/kie-wb-webapp/src/main/webapp/WEB-INF/web.xml
@@ -685,7 +685,12 @@ See http://www.w3.org/TR/SVG/intro.html#MIMEType. -->
   </filter>
   <filter-mapping>
     <filter-name>Dynamic JAXBContext Filter</filter-name>
-    <url-pattern>/rest/*</url-pattern>
+    <url-pattern>/rest/deployment/*</url-pattern>
+    <url-pattern>/rest/history*</url-pattern>
+    <url-pattern>/rest/task/*</url-pattern>
+    <url-pattern>/rest/runtime/*</url-pattern>
+    <url-pattern>/rest/query/*</url-pattern>
+    <url-pattern>/rest/execute/*</url-pattern>
     <url-pattern>/ws/*</url-pattern>
   </filter-mapping>
 


### PR DESCRIPTION
…yment id from the servlet request xml content - list only required rest endpoints url patterns to avoid affecting non related

required change to allow kie server controller to work properly in workbench. This is follow up of side effect caused by this change:
https://github.com/droolsjbpm/droolsjbpm-integration/commit/cb934147405e99b96726cf95f96a12ed9453964e#diff-63ea5c658165dc367065248c63d4828fR175
that results in following error:
```
08:40:07,707 ERROR [org.jboss.resteasy.resteasy_jaxrs.i18n] (http-localhost/127.0.0.1:8080-5) RESTEASY000100: Failed executing PUT controller/server/KieServer1: org.jboss.resteasy.spi.ReaderException: java.lang.IllegalStateException: JBWEB000039: getReader() has already been called for this request
	at org.jboss.resteasy.core.MessageBodyParameterInjector.inject(MessageBodyParameterInjector.java:201) [resteasy-jaxrs-2.3.10.Final-redhat-1.jar:]
	at org.jboss.resteasy.core.MethodInjectorImpl.injectArguments(MethodInjectorImpl.java:137) [resteasy-jaxrs-2.3.10.Final-redhat-1.jar:]
	at org.jboss.resteasy.core.MethodInjectorImpl.invoke(MethodInjectorImpl.java:160) [resteasy-jaxrs-2.3.10.Final-redhat-1.jar:]
	at org.jboss.resteasy.core.ResourceMethod.invokeOnTarget(ResourceMethod.java:269) [resteasy-jaxrs-2.3.10.Final-redhat-1.jar:]
	at org.jboss.resteasy.core.ResourceMethod.invoke(ResourceMethod.java:227) [resteasy-jaxrs-2.3.10.Final-redhat-1.jar:]
	at org.jboss.resteasy.core.ResourceMethod.invoke(ResourceMethod.java:216) [resteasy-jaxrs-2.3.10.Final-redhat-1.jar:]
	at org.jboss.resteasy.core.SynchronousDispatcher.getResponse(SynchronousDispatcher.java:541) [resteasy-jaxrs-2.3.10.Final-redhat-1.jar:]
	at org.jboss.resteasy.core.SynchronousDispatcher.invoke(SynchronousDispatcher.java:523) [resteasy-jaxrs-2.3.10.Final-redhat-1.jar:]
	at org.jboss.resteasy.core.SynchronousDispatcher.invoke(SynchronousDispatcher.java:125) [resteasy-jaxrs-2.3.10.Final-redhat-1.jar:]
	at org.jboss.resteasy.plugins.server.servlet.ServletContainerDispatcher.service(ServletContainerDispatcher.java:208) [resteasy-jaxrs-2.3.10.Final-redhat-1.jar:]
	at org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher.service(HttpServletDispatcher.java:55) [resteasy-jaxrs-2.3.10.Final-redhat-1.jar:]
	at org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher.service(HttpServletDispatcher.java:50) [resteasy-jaxrs-2.3.10.Final-redhat-1.jar:]
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:847) [jboss-servlet-api_3.0_spec-1.0.2.Final-redhat-1.jar:1.0.2.Final-redhat-1]
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:295) [jbossweb-7.5.4.Final-redhat-1.jar:7.5.4.Final-redhat-1]
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:214) [jbossweb-7.5.4.Final-redhat-1.jar:7.5.4.Final-redhat-1]
	at org.kie.remote.services.rest.jaxb.DynamicJaxbContextFilter.doFilter(DynamicJaxbContextFilter.java:81) [kie-remote-services-6.4.0-SNAPSHOT.jar:6.4.0-SNAPSHOT]
```
@mrietveld could you please double check if all rest endpoints that should be there are included?