### PR TITLE
[BZ-1207318] clean-up few deps to avoid duplicit classes with same FQN

### DIFF
--- a/kie-drools-wb/kie-drools-wb-webapp/pom.xml
+++ b/kie-drools-wb/kie-drools-wb-webapp/pom.xml
@@ -660,6 +660,18 @@
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>
+        <!-- designer-backend already brings avalon-framework which contains the same classes as avalon-framework-api.
+             This should be fixed directly in designer-backed. -->
+        <exclusion>
+          <groupId>org.apache.avalon.framework</groupId>
+          <artifactId>avalon-framework-api</artifactId>
+        </exclusion>
+        <!-- Not needed at runtime. Clashes with com.google.code.findbugs:annotations. Should be probably fixed directly
+             in designer-backed. -->
+        <exclusion>
+          <groupId>com.google.code.findbugs</groupId>
+          <artifactId>jsr305</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 
@@ -994,6 +1006,13 @@
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-data-binding</artifactId>
       <scope>provided</scope>
+      <exclusions>
+        <!-- This is a transitive dependency of guava-gwt. It is not needed at runtime (nor for GWT compile) -->
+        <exclusion>
+          <groupId>com.google.code.findbugs</groupId>
+          <artifactId>jsr305</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!-- Errai AS -->

--- a/kie-wb/kie-wb-webapp/pom.xml
+++ b/kie-wb/kie-wb-webapp/pom.xml
@@ -857,6 +857,13 @@
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-data-binding</artifactId>
       <scope>provided</scope>
+      <exclusions>
+        <!-- This is a transitive dependency of guava-gwt. It is not needed at runtime (nor for GWT compile) -->
+        <exclusion>
+          <groupId>com.google.code.findbugs</groupId>
+          <artifactId>jsr305</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!-- CDI Integration Modules -->
@@ -936,6 +943,18 @@
         <exclusion>
           <groupId>org.slf4j</groupId>
           <artifactId>log4j-over-slf4j</artifactId>
+        </exclusion>
+        <!-- designer-backend already brings avalon-framework which contains the same classes as avalon-framework-api.
+             This should be fixed directly in designer-backed. -->
+        <exclusion>
+          <groupId>org.apache.avalon.framework</groupId>
+          <artifactId>avalon-framework-api</artifactId>
+        </exclusion>
+        <!-- Not needed at runtime. Clashes with com.google.code.findbugs:annotations. Should be probably fixed directly
+             in designer-backed. -->
+        <exclusion>
+          <groupId>com.google.code.findbugs</groupId>
+          <artifactId>jsr305</artifactId>
         </exclusion>
       </exclusions>
     </dependency>


### PR DESCRIPTION
 * classes in the excluded jars are also provided
   by different jars. Having classes with same FQN
   in two different jars leads to hard to debug
   runtime issues as only one of those classes gets
   loaded (and there is no way to tell which one
   exactly)

 * there is few more duplicit classes that need to be looked at