### PR TITLE
[BZ-1207318] remove duplicated jaxrs jar in Tomcat distro

### DIFF
--- a/kie-wb/kie-wb-distribution-wars/src/main/assembly/component-kie-wb-tomcat-7-common.xml
+++ b/kie-wb/kie-wb-distribution-wars/src/main/assembly/component-kie-wb-tomcat-7-common.xml
@@ -40,7 +40,6 @@
           <include>org.jboss.spec.javax.servlet.jstl:jboss-jstl-api_1.2_spec</include>
           <include>org.jboss.spec.javax.jms:jboss-jms-api_1.1_spec</include>
           <include>org.jboss.spec.javax.xml.ws:jboss-jaxws-api_2.2_spec</include>
-          <include>org.jboss.spec.javax.ws.rs:jboss-jaxrs-api_1.1_spec</include>
           <include>org.jboss.spec.javax.xml.bind:jboss-jaxb-api_2.2_spec</include>
           <include>org.jboss.spec.javax.ejb:jboss-ejb-api_3.1_spec</include>
 


### PR DESCRIPTION
@mrietveld @mswiderski please take a look. We are bundling both `resteasy-jaxrs-api` and `jboss-jaxrs-api_1.1_spec` in the Tomcat WAR. One of them needs to be removed, I am just not 100 % sure which one. I picked the `jboss-jaxrs-api_1.1_spec`, but we may change that if needed.