### PR TITLE
smoke-tests: add possibility to execute tests on prod binaries

### DIFF
--- a/kie-wb-smoke-tests/README.md
+++ b/kie-wb-smoke-tests/README.md
@@ -25,3 +25,17 @@ different port.
 You can now run (and debug) the tests easily from IDE by just executing the `@Test` annotated
 methods.
 
+How to execute tests for different containers and apps
+======================================================
+By default, when you run `mvn clean install` _no_ tests will be executed. Tests are executed either when specifying `full`
+profile (by setting `-Dfull`) or when configuring explicit container and deployable profiles. The tests can be also executed
+on the productized binaries (by setting `-Dproductized`).
+
+Examples of different scenarios:
+
+  * `mvn clean install` - tests are only compiled. Execution is skipped.
+  * `mvn clean install -Dfull` - default configuration is used. The tests are executed on KIE Workbench deployed to Tomcat 7.
+  * `mvn clean install -Dfull -Dproductized` - same as above, but productized WAR (e.g. tomcat7-redhat) is used.
+  * `mvn clean install -Pwildfly8x,kie-drools-wb` - tests are executed on KIE Drools Workbench deployed to WildFly 8.
+  * `mvn clean install -Peap64x,kie-wb -Dproductized` - tests are executed on productized KIE Workbench (eap6_4-redhat) deployed to EAP 6.4
+  * `mvn clean install -Dcustom-container -Ddeployable.base.uri=<value>` - tests will be executed on custom container, which needs to be already running.

--- a/kie-wb-smoke-tests/pom.xml
+++ b/kie-wb-smoke-tests/pom.xml
@@ -20,6 +20,9 @@
     <version.wildfly8>8.2.1.Final</version.wildfly8>
     <version.wildfly9>9.0.1.Final</version.wildfly9>
 
+    <tomcat7x.deployable.classifier>tomcat7</tomcat7x.deployable.classifier>
+    <wildfly8x.deplyoble.classifier>wildfly8</wildfly8x.deplyoble.classifier>
+    <eap64x.deployable.classifier>eap6_4</eap64x.deployable.classifier>
     <!-- The default setup (if not overidden by specific profile) will execute kie-wb smoke tests on EAP 6.4.x -->
     <!-- These properties are overriden in profiles kie-drools-wb and kie-wb -->
     <deployable.groupId>org.kie</deployable.groupId>
@@ -33,6 +36,39 @@
     <deployment.timeout.millis>120000</deployment.timeout.millis>
   </properties>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.kie</groupId>
+        <artifactId>kie-wb-distribution-wars</artifactId>
+        <version>${version.org.kie}</version>
+        <type>war</type>
+        <classifier>tomcat7-redhat</classifier>
+      </dependency>
+      <dependency>
+        <groupId>org.kie</groupId>
+        <artifactId>kie-drools-wb-distribution-wars</artifactId>
+        <version>${version.org.kie}</version>
+        <type>war</type>
+        <classifier>tomcat7-redhat</classifier>
+      </dependency>
+      <dependency>
+        <groupId>org.kie</groupId>
+        <artifactId>kie-wb-distribution-wars</artifactId>
+        <version>${version.org.kie}</version>
+        <type>war</type>
+        <classifier>eap6_4-redhat</classifier>
+      </dependency>
+      <dependency>
+        <groupId>org.kie</groupId>
+        <artifactId>kie-drools-wb-distribution-wars</artifactId>
+        <version>${version.org.kie}</version>
+        <type>war</type>
+        <classifier>eap6_4-redhat</classifier>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+  
   <dependencies>
     <!-- utilities -->
     <dependency>
@@ -288,7 +324,9 @@
     <profile>
       <id>kie-wb</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <property>
+          <name>full</name>
+        </property>
       </activation>
       <properties>
         <deployable.groupId>org.kie</deployable.groupId>
@@ -323,13 +361,13 @@
         <dependency>
           <groupId>org.kie</groupId>
           <artifactId>kie-wb-distribution-wars</artifactId>
-          <classifier>eap6_4</classifier>
+          <classifier>${eap64x.deployable.classifier}</classifier>
           <type>war</type>
         </dependency>
         <dependency>
           <groupId>org.kie</groupId>
           <artifactId>kie-drools-wb-distribution-wars</artifactId>
-          <classifier>eap6_4</classifier>
+          <classifier>${eap64x.deployable.classifier}</classifier>
           <type>war</type>
         </dependency>
       </dependencies>
@@ -368,7 +406,7 @@
                 <deployable>
                   <groupId>${deployable.groupId}</groupId>
                   <artifactId>${deployable.artifactId}</artifactId>
-                  <classifier>eap6_4</classifier>
+                  <classifier>${eap64x.deployable.classifier}</classifier>
                   <type>war</type>
                 </deployable>
               </deployables>
@@ -379,17 +417,22 @@
     </profile>
     <profile>
       <id>tomcat7x</id>
+      <activation>
+        <property>
+          <name>full</name>
+        </property>
+      </activation>
       <dependencies>
         <dependency>
           <groupId>org.kie</groupId>
           <artifactId>kie-wb-distribution-wars</artifactId>
-          <classifier>tomcat7</classifier>
+          <classifier>${tomcat7x.deployable.classifier}</classifier>
           <type>war</type>
         </dependency>
         <dependency>
           <groupId>org.kie</groupId>
           <artifactId>kie-drools-wb-distribution-wars</artifactId>
-          <classifier>tomcat7</classifier>
+          <classifier>${tomcat7x.deployable.classifier}</classifier>
           <type>war</type>
         </dependency>
       </dependencies>
@@ -469,7 +512,7 @@
                 <deployable>
                   <groupId>${deployable.groupId}</groupId>
                   <artifactId>${deployable.artifactId}</artifactId>
-                  <classifier>tomcat7</classifier>
+                  <classifier>${tomcat7x.deployable.classifier}</classifier>
                   <type>war</type>
                 </deployable>
               </deployables>
@@ -601,20 +644,17 @@
 
     <profile>
       <id>wildfly8x</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
       <dependencies>
         <dependency>
           <groupId>org.kie</groupId>
           <artifactId>kie-wb-distribution-wars</artifactId>
-          <classifier>wildfly8</classifier>
+          <classifier>${wildfly8x.deplyoble.classifier}</classifier>
           <type>war</type>
         </dependency>
         <dependency>
           <groupId>org.kie</groupId>
           <artifactId>kie-drools-wb-distribution-wars</artifactId>
-          <classifier>wildfly8</classifier>
+          <classifier>${wildfly8x.deplyoble.classifier}</classifier>
           <type>war</type>
         </dependency>
       </dependencies>
@@ -654,7 +694,7 @@
                 <deployable>
                   <groupId>${deployable.groupId}</groupId>
                   <artifactId>${deployable.artifactId}</artifactId>
-                  <classifier>wildfly8</classifier>
+                  <classifier>${wildfly8x.deplyoble.classifier}</classifier>
                   <type>war</type>
                 </deployable>
               </deployables>
@@ -669,13 +709,13 @@
         <dependency>
           <groupId>org.kie</groupId>
           <artifactId>kie-wb-distribution-wars</artifactId>
-          <classifier>wildfly8</classifier>
+          <classifier>${wildfly8x.deplyoble.classifier}</classifier>
           <type>war</type>
         </dependency>
         <dependency>
           <groupId>org.kie</groupId>
           <artifactId>kie-drools-wb-distribution-wars</artifactId>
-          <classifier>wildfly8</classifier>
+          <classifier>${wildfly8x.deplyoble.classifier}</classifier>
           <type>war</type>
         </dependency>
       </dependencies>
@@ -715,7 +755,7 @@
                 <deployable>
                   <groupId>${deployable.groupId}</groupId>
                   <artifactId>${deployable.artifactId}</artifactId>
-                  <classifier>wildfly8</classifier>
+                  <classifier>${wildfly8x.deplyoble.classifier}</classifier>
                   <type>war</type>
                 </deployable>
               </deployables>
@@ -724,15 +764,11 @@
         </plugins>
       </build>
     </profile>
-    <!-- This profile basically disables any cargo related execution. It can be used when the tests should run on
-         a container that has already been started and it is not managed by cargo. It can also be used when doing
-         a "no-test" build, as the container should not be used in that case. -->
+    <!-- Tests are disabled by default. They run with "full" build (e.g. mvn clean install -Dfull) -->
     <profile>
-      <id>custom-container</id>
+      <id>disable-cargo-and-tests</id>
       <activation>
-        <property>
-          <name>custom-container</name>
-        </property>
+        <activeByDefault>true</activeByDefault>
       </activation>
       <build>
         <plugins>
@@ -743,18 +779,76 @@
               <execution>
                 <id>start-container</id>
                 <phase>none</phase>
-                <!-- do nothing, container is not managed by cargo! -->
+                <!-- do nothing, container is not managed by Cargo! -->
                 <goals/>
               </execution>
               <execution>
                 <id>stop-container</id>
                 <phase>none</phase>
-                <!-- do nothing, container is not managed by cargo! -->
+                <!-- do nothing, container is not managed by Cargo! -->
                 <goals/>
               </execution>
             </executions>
           </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <configuration>
+              <skipITs>true</skipITs>
+            </configuration>
+          </plugin>
         </plugins>
+      </build>
+    </profile>
+
+    <!-- This profile basically disables any Cargo related execution, but runs the tests. It can be used when the tests
+         should run on a container that has already been started and it is not managed by Cargo. It can also be used
+         when doing a "no-test" build, as the container should not be used in that case. -->
+    <profile>
+      <id>custom-container</id>
+      <activation>
+        <property>
+          <name>custom-container</name>
+        </property>
+      </activation>
+    </profile>
+
+    <profile>
+      <id>productized</id>
+      <activation>
+        <property>
+          <name>productized</name>
+        </property>
+      </activation>
+
+      <properties>
+        <tomcat7x.deployable.classifier>tomcat7-redhat</tomcat7x.deployable.classifier>
+        <!-- There is no WildFly 8 productized WAR -->
+        <wildlfy8x.deployable.classifier>NONE</wildlfy8x.deployable.classifier>
+        <eap64x.deployable.classifier>eap6_4-redhat</eap64x.deployable.classifier>
+      </properties>
+    </profile>
+
+    <profile>
+      <id>full</id>
+      <activation>
+        <property>
+          <name>full</name>
+        </property>
+      </activation>
+
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-failsafe-plugin</artifactId>
+              <configuration>
+                <skipITs>false</skipITs>
+              </configuration>
+            </plugin>
+          </plugins>
+        </pluginManagement>
       </build>
     </profile>
   </profiles>


### PR DESCRIPTION
 * these changes enable execution of the tests on productized
   binaries (classifier ending with -redhat).
 * this should make it very easy to verify the productization
   process did not break anything (same tests need to pass before
   on community binaries and after on prod binaries)

* @mrietveld please take a quick a look in case I missed something