### PR TITLE
InternetExplorer setup in selenium smokes

### DIFF
--- a/kie-wb-smoke-tests/pom.xml
+++ b/kie-wb-smoke-tests/pom.xml
@@ -94,6 +94,10 @@
       <artifactId>selenium-firefox-driver</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.seleniumhq.selenium</groupId>
+      <artifactId>selenium-ie-driver</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>
@@ -367,8 +371,10 @@
     </profile>
 
     <profile>
-      <!-- Enable selenium-based smoke tests to run. E.g.
-           mvn clean install -Pwildfly8x,selenium,kie-wb  -->
+      <!-- Enable selenium UI smoke tests to be run with Firefox. 
+      Example usage: mvn clean install -Pwildfly8x,kie-wb,selenium
+           
+      To use Internet Explorer see profile ie -->
       <id>selenium</id>
       <activation>
         <property>
@@ -376,17 +382,64 @@
         </property>
       </activation>
       <build>
-        <pluginManagement>
-          <plugins>
-            <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-failsafe-plugin</artifactId>
-              <configuration>
-                <groups>org.kie.smoke.wb.category.KieWbSeleniumSmoke</groups>
-              </configuration>
-            </plugin>
-          </plugins>
-        </pluginManagement>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <configuration>
+              <groups>org.kie.smoke.wb.category.KieWbSeleniumSmoke</groups>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    
+    <profile>
+      <!--  Enable selenium UI smoke tests to be run with Internet Explorer.
+      Example usage: mvn clean install -Pwildfly8x,kie-wb,selenium,ie -->
+      <id>ie</id>
+      <activation>
+        <property>
+          <name>ie</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin> <!-- Downloads and unzips IEDriverServer.exe and then sets the
+            system property 'webdriver.ie.driver' needed to instantiate InternetExplorerDriver -->
+            <groupId>com.lazerycode.selenium</groupId>
+            <artifactId>driver-binary-downloader-maven-plugin</artifactId>
+            <version>1.0.7</version>
+            <configuration>
+              <!-- Where to download zips with selenium binaries -->
+              <downloadedZipFileDirectory>${java.io.tmpdir}/selenium_zips</downloadedZipFileDirectory>
+              <!-- Where to unzip browser specific binaries (IEDriverServer.exe, chromedriver) -->
+              <rootStandaloneServerDirectory>${project.build.directory}/selenium_binaries</rootStandaloneServerDirectory>
+              <!-- Config specifying download urls / md5 hashes for selenium binaries -->
+              <customRepositoryMap>${project.build.testOutputDirectory}/driver-binary-urls.xml</customRepositoryMap>
+            </configuration>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>selenium</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <configuration>
+              <systemPropertyVariables>
+                <!-- property to let the tests know which browser we're using -->
+                <browser>ie</browser>
+                <!-- The following maven property is set by driver-binary-downloader-maven-plugin.
+                Copy it as system property for InternetExplorerDriver-->
+                <webdriver.ie.driver>${webdriver.ie.driver}</webdriver.ie.driver>                
+              </systemPropertyVariables>
+            </configuration>
+          </plugin>
+        </plugins>
       </build>
     </profile>
 

--- a/kie-wb-smoke-tests/src/main/java/org/kie/smoke/wb/selenium/model/KieSeleniumTest.java
+++ b/kie-wb-smoke-tests/src/main/java/org/kie/smoke/wb/selenium/model/KieSeleniumTest.java
@@ -19,7 +19,6 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.kie.smoke.wb.selenium.util.PageObjectFactory;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.firefox.FirefoxDriver;
 
 public class KieSeleniumTest {
 
@@ -28,14 +27,14 @@ public class KieSeleniumTest {
 
     @BeforeClass
     public static void startWebDriver() {
-        //TODO - logic to choose WebDriver implementation based on configuration
-        //TODO - InternetExplorerDriver & ChromeDriver require additional binary file to run
-        driver = new FirefoxDriver();
+        driver = WebDriverFactory.create();
         pof = new PageObjectFactory(driver);
     }
 
     @AfterClass
     public static void stopWebDriver() {
-        driver.close();
+        if (driver != null) {
+            driver.quit();
+        }
     }
 }

--- a/kie-wb-smoke-tests/src/main/java/org/kie/smoke/wb/selenium/model/WebDriverFactory.java
+++ b/kie-wb-smoke-tests/src/main/java/org/kie/smoke/wb/selenium/model/WebDriverFactory.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2015 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.smoke.wb.selenium.model;
+
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.firefox.FirefoxDriver;
+import org.openqa.selenium.ie.InternetExplorerDriver;
+
+/**
+ * Class responsible for instantiating WebDriver instance.
+ */
+public class WebDriverFactory {
+
+    public static WebDriver create() {
+        String browser = System.getProperty("browser");
+        if (browser == null || "firefox".equalsIgnoreCase(browser)) {
+            return new FirefoxDriver();
+        } else if ("ie".equalsIgnoreCase(browser)) {
+            // System property "webdriver.ie.driver" specifying path to IEDriverServer.exe
+            // is set by failsafe plugin configuration kie-wb-smoke-tests's pom.xml in "ie" profile
+            return new InternetExplorerDriver();
+        } else {
+            throw new IllegalArgumentException("Unrecognized value of property browser='" + browser
+                    + "'. The only supported values are 'ie', 'firefox' or null (= defaults to firefox)");
+        }
+    }
+}

--- a/kie-wb-smoke-tests/src/test/resources/driver-binary-urls.xml
+++ b/kie-wb-smoke-tests/src/test/resources/driver-binary-urls.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<root>
+  <windows>
+    <driver id="internetexplorer">
+      <version id="2.46.0"> <!-- The versions of these binaries are unfortunately
+         NOT kept in sync with selenium version. E.g. we can have selenium version 2.46.2,
+         but we have to use IEDriverServer version 2.46.0-->
+        <bitrate sixtyfourbit="true" thirtytwobit="true">
+          <!-- Use 32bit IEDriverServer binary both on 32 & 64bit windows.
+           There is a known issue with 64bit binary that makes typing into input elements very slow (1 character per 5 seconds)
+           https://code.google.com/p/selenium/issues/detail?id=5116
+          -->
+          <filelocation>http://selenium-release.storage.googleapis.com/2.46/IEDriverServer_Win32_2.46.0.zip</filelocation>
+          <hash>93616ec22088413ff9d8dec978d94474</hash>
+          <hashtype>md5</hashtype>
+        </bitrate>
+      </version>
+    </driver>
+  </windows>
+  <linux><!-- must be present, even though not used --></linux>
+  <osx><!-- must be present, even though not used --></osx>
+</root>


### PR DESCRIPTION
THIS PR IS MERGE READY

Setup for using InternetExplorerDriver in selenium smoke tests.
I configured existing driver-binary-downloader-maven-plugin to download, cache and unzip IEDriverServer.exe binary required to run InternetExplorerDriver. This plugin also sets webdriver.ie.driver maven property, which is made available to tests via failsafe plugin configuration.

Example usage:
    mvn clean install -Pwildfly8x,selenium,kie-wb # use Firefox by default
    mvn clean install -Pwildfly8x,selenium,kie-wb,ie # ie profile enables tests with InternetExplorer (windows only)

I tested this on Windows 8 with IE 11 and it's working fine. During the testing I encountered one long-known issue with 64bit IEDriverServer [1]. This issue causes typing into input elements to be very slow (1 character per 5 secons). I applied the know workaround, which is to use 32bit IEDriverServer binary on both 32 and 64bit machines.

[1] https://code.google.com/p/selenium/issues/detail?id=5116