### PR TITLE
Remove obsolete profile config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,18 +129,6 @@
       </modules>
     </profile>
 
-    <profile>
-      <id>functionalTests</id>
-      <activation>
-        <property>
-          <name>functionalTests</name>
-        </property>
-      </activation>
-      <modules>
-        <module>kie-wb-webapp-test</module>
-      </modules>
-    </profile>
-
   </profiles>
 
 </project>


### PR DESCRIPTION
That module no longer exists. Tests were moved into `kie-wb-smoke-tests`.