### PR TITLE
(6.3.x) BZ1192831: User with no privileges for Repository can view and modify assets in that Repository. Ensure the same instance of RuntimeAuthorizationManager is used.

### DIFF
--- a/kie-drools-wb/kie-drools-wb-webapp/src/main/java/org/kie/workbench/drools/backend/server/ApplicationScopedProducer.java
+++ b/kie-drools-wb/kie-drools-wb-webapp/src/main/java/org/kie/workbench/drools/backend/server/ApplicationScopedProducer.java
@@ -47,12 +47,13 @@ import org.uberfire.security.impl.authz.RuntimeAuthorizationManager;
 @ApplicationScoped
 public class ApplicationScopedProducer {
 
+    private IOService ioService;
+    private IOSearchService ioSearchService;
+    private AuthorizationManager authorizationManager = new RuntimeAuthorizationManager();
+
     @Inject
     @Named("luceneConfig")
     private LuceneConfig config;
-
-    private IOService ioService;
-    private IOSearchService ioSearchService;
 
     @Inject
     private IOWatchServiceNonDotImpl watchService;
@@ -111,7 +112,7 @@ public class ApplicationScopedProducer {
 
     @Produces
     public AuthorizationManager getAuthManager() {
-        return new RuntimeAuthorizationManager();
+        return authorizationManager;
     }
 
     @Produces

--- a/kie-drools-wb/kie-drools-wb-webapp/src/test/java/org/kie/workbench/drools/backend/server/ApplicationScopedProducerTest.java
+++ b/kie-drools-wb/kie-drools-wb-webapp/src/test/java/org/kie/workbench/drools/backend/server/ApplicationScopedProducerTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2015 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.drools.backend.server;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.uberfire.security.authz.AuthorizationManager;
+
+import static org.junit.Assert.*;
+
+public class ApplicationScopedProducerTest {
+
+    private String spWatcherAutoStart = null;
+    private String spDeploymentLocation = null;
+
+    @Before
+    public void storeSystemProperties() {
+        spWatcherAutoStart = System.getProperty( "org.uberfire.watcher.autostart" );
+        spDeploymentLocation = System.getProperty( "org.kie.deployment.desc.location" );
+    }
+
+    @After
+    public void restoreSystemProperties() {
+        if ( spWatcherAutoStart != null ) {
+            System.setProperty( "org.uberfire.watcher.autostart",
+                                spWatcherAutoStart );
+        }
+        if ( spDeploymentLocation != null ) {
+            System.setProperty( "org.kie.deployment.desc.location",
+                                spDeploymentLocation );
+        }
+    }
+
+    @Test
+    public void testRuntimeAuthorizationManagerProducer() {
+        final ApplicationScopedProducer asp = new ApplicationScopedProducer();
+        final AuthorizationManager am1 = asp.getAuthManager();
+        final AuthorizationManager am2 = asp.getAuthManager();
+        assertSame( am1,
+                    am2 );
+    }
+
+}

--- a/kie-wb/kie-wb-webapp/src/main/java/org/kie/workbench/backend/ApplicationScopedProducer.java
+++ b/kie-wb/kie-wb-webapp/src/main/java/org/kie/workbench/backend/ApplicationScopedProducer.java
@@ -50,12 +50,13 @@ import org.uberfire.security.impl.authz.RuntimeAuthorizationManager;
 @ApplicationScoped
 public class ApplicationScopedProducer {
 
+    private IOService ioService;
+    private IOSearchService ioSearchService;
+    private AuthorizationManager authorizationManager = new RuntimeAuthorizationManager();
+
     @Inject
     @Named("luceneConfig")
     private LuceneConfig config;
-
-    private IOService ioService;
-    private IOSearchService ioSearchService;
 
     @Inject
     @Named("clusterServiceFactory")
@@ -115,7 +116,7 @@ public class ApplicationScopedProducer {
 
     @Produces
     public AuthorizationManager getAuthManager() {
-        return new RuntimeAuthorizationManager();
+        return authorizationManager;
     }
 
     @Produces

--- a/kie-wb/kie-wb-webapp/src/test/java/org/kie/workbench/backend/ApplicationScopedProducerTest.java
+++ b/kie-wb/kie-wb-webapp/src/test/java/org/kie/workbench/backend/ApplicationScopedProducerTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2015 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.backend;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.uberfire.security.authz.AuthorizationManager;
+
+import static org.junit.Assert.*;
+
+public class ApplicationScopedProducerTest {
+
+    private String spWatcherAutoStart = null;
+    private String spDeploymentLocation = null;
+
+    @Before
+    public void storeSystemProperties() {
+        spWatcherAutoStart = System.getProperty( "org.uberfire.watcher.autostart" );
+        spDeploymentLocation = System.getProperty( "org.kie.deployment.desc.location" );
+    }
+
+    @After
+    public void restoreSystemProperties() {
+        if ( spWatcherAutoStart != null ) {
+            System.setProperty( "org.uberfire.watcher.autostart",
+                                spWatcherAutoStart );
+        }
+        if ( spDeploymentLocation != null ) {
+            System.setProperty( "org.kie.deployment.desc.location",
+                                spDeploymentLocation );
+        }
+    }
+
+    @Test
+    public void testRuntimeAuthorizationManagerProducer() {
+        final ApplicationScopedProducer asp = new ApplicationScopedProducer();
+        final AuthorizationManager am1 = asp.getAuthManager();
+        final AuthorizationManager am2 = asp.getAuthManager();
+        assertSame( am1,
+                    am2 );
+    }
+
+}


### PR DESCRIPTION
See https://bugzilla.redhat.com/show_bug.cgi?id=1192831

This is the final piece of the jigsaw.. multiple instances of ```RuntimeAuthorizationManager``` were being created which was leading to authorization behaving unpredictably.