### PR TITLE
[BZ-1020902] exclude source files from WARs

### DIFF
--- a/kie-drools-wb/kie-drools-wb-webapp/pom.xml
+++ b/kie-drools-wb/kie-drools-wb-webapp/pom.xml
@@ -1480,7 +1480,8 @@
           <execution>
             <id>gwt-compile</id>
             <goals>
-              <goal>resources</goal>
+              <!-- Do not use 'resources' goal as it does not play well with resource filtering and is adding Java
+                   source files into the build output directory (and they then end up in the WAR). -->
               <goal>compile</goal>
             </goals>
           </execution>
@@ -1490,10 +1491,12 @@
         <artifactId>maven-war-plugin</artifactId>
         <configuration>
           <packagingExcludes>
-            **/javax/**/*.*,
-            **/client/**/*.class,
-            **/*.symbolMap,
-            WEB-INF/classes/logback.xml
+            WEB-INF/classes/javax/**/*.*,
+            WEB-INF/classes/**/client/**/*.class,
+            WEB-INF/classes/**/public/**,
+            WEB-INF/classes/logback.xml,
+            **/*.gwt.xml,
+            **/*.symbolMap
           </packagingExcludes>
           <archive>
             <addMavenDescriptor>false</addMavenDescriptor>

--- a/kie-wb/kie-wb-webapp/pom.xml
+++ b/kie-wb/kie-wb-webapp/pom.xml
@@ -1727,7 +1727,8 @@
           <execution>
             <id>gwt-compile</id>
             <goals>
-              <goal>resources</goal>
+              <!-- Do not use 'resources' goal as it does not play well with resource filtering and is adding Java
+                   source files into the build output directory (and they then end up in the WAR). -->
               <goal>compile</goal>
             </goals>
           </execution>
@@ -1737,10 +1738,12 @@
         <artifactId>maven-war-plugin</artifactId>
         <configuration>
           <packagingExcludes>
-            **/javax/**/*.*,
-            **/client/**/*.class,
-            **/*.symbolMap,
-            WEB-INF/classes/logback.xml
+            WEB-INF/classes/javax/**/*.*,
+            WEB-INF/classes/**/client/**/*.class,
+            WEB-INF/classes/**/public/**,
+            WEB-INF/classes/logback.xml,
+            **/*.gwt.xml,
+            **/*.symbolMap
           </packagingExcludes>
           <archive>
             <addMavenDescriptor>false</addMavenDescriptor>


### PR DESCRIPTION
Source files are useless in the WAR, so no need to have them there. 

Adjusted a bit the other exclude patterns to make it clearer what they are targeting.