### PR TITLE
UF-244: (Work-around) Default DEV environment to Wildfly 10.0.0(CR4)

### DIFF
--- a/kie-drools-wb/kie-drools-wb-webapp/pom.xml
+++ b/kie-drools-wb/kie-drools-wb-webapp/pom.xml
@@ -127,6 +127,11 @@
       <artifactId>javax.inject</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>com.github.gwtbootstrap</groupId>
+      <artifactId>gwt-bootstrap</artifactId>
+      <scope>provided</scope>
+    </dependency>
 
     <dependency>
       <groupId>org.jboss.resteasy</groupId>

--- a/kie-drools-wb/kie-drools-wb-webapp/pom.xml
+++ b/kie-drools-wb/kie-drools-wb-webapp/pom.xml
@@ -1282,6 +1282,7 @@
             <extraJvmArgs>${gwt.memory.settings} -XX:CompileThreshold=7000 -Derrai.jboss.home=${errai.jboss.home}
               -Derrai.marshalling.server.classOutput=${project.build.outputDirectory} -Dorg.kie.demo=true
               -Dorg.kie.clean.onstartup=true -Dorg.jbpm.designer.perspective=ruleflow -Djava.util.prefs.syncInterval=2000000
+              -Dorg.uberfire.async.executor.safemode=true
             </extraJvmArgs>
             <draftCompile>true</draftCompile>
             <module>org.kie.workbench.drools.FastCompiledKIEDroolsWebapp</module>

--- a/kie-wb/kie-wb-webapp/pom.xml
+++ b/kie-wb/kie-wb-webapp/pom.xml
@@ -1515,6 +1515,7 @@
             <extraJvmArgs>${gwt.memory.settings} -XX:CompileThreshold=7000 -Derrai.jboss.home=${errai.jboss.home} 
               -Derrai.marshalling.server.classOutput=${project.build.outputDirectory} -Dorg.kie.demo=true 
               -Dorg.kie.clean.onstartup=true -Dorg.uberfire.nio.git.ssh.enabled=false -Djava.util.prefs.syncInterval=2000000
+              -Dorg.uberfire.async.executor.safemode=true
             </extraJvmArgs>
             <draftCompile>true</draftCompile>
             <module>org.kie.workbench.FastCompiledKIEWebapp</module>

--- a/kie-wb/kie-wb-webapp/pom.xml
+++ b/kie-wb/kie-wb-webapp/pom.xml
@@ -127,6 +127,11 @@
       <artifactId>javax.inject</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>com.github.gwtbootstrap</groupId>
+      <artifactId>gwt-bootstrap</artifactId>
+      <scope>provided</scope>
+    </dependency>
 
     <dependency>
       <groupId>org.jboss.resteasy</groupId>


### PR DESCRIPTION
See https://issues.jboss.org/browse/UF-244

This PR provides a workaround to the issue (of ```Async``` EJBs not running on Wildfly 8.1 - which is our Hosted Mode environment). Support for System Property ```org.uberfire.async.executor.safemode``` to force use of ```Executors.newCachedThreadPool``` has been added. 

This PR sets the said System Property to "true" to ensure Hosted Mode (which uses Wildfly 8.1) works without further ado with ```mvn gwt:run``` or from your favourite IDE. 