### PR TITLE
Do not disable other smoke tests when running Selenium tests

### DIFF
--- a/kie-wb-smoke-tests/pom.xml
+++ b/kie-wb-smoke-tests/pom.xml
@@ -371,10 +371,12 @@
     </profile>
 
     <profile>
-      <!-- Enable selenium UI smoke tests to be run with Firefox. 
-      Example usage: mvn clean install -Pwildfly8x,kie-wb,selenium
-           
-      To use Internet Explorer see profile ie -->
+      <!-- Enable selenium UI smoke tests to be run with Firefox.
+
+           Example usage: mvn clean install -Pwildfly8x,kie-wb,selenium (executes all default smoke tests + UI ones)
+                          mvn clean install -Pwildfly8x,kie-wb,selenium -Dit.test=LoginIntegrationTest (executes just one test)
+
+           To use Internet Explorer see profile 'ie' -->
       <id>selenium</id>
       <activation>
         <property>
@@ -386,9 +388,18 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <configuration>
-              <groups>org.kie.smoke.wb.category.KieWbSeleniumSmoke</groups>
-            </configuration>
+            <executions>
+              <execution>
+                <id>selenium-tests</id>
+                <phase>integration-test</phase>
+                <goals>
+                  <goal>integration-test</goal>
+                </goals>
+                <configuration>
+                  <groups>org.kie.smoke.wb.category.KieWbSeleniumSmoke</groups>
+                </configuration>
+              </execution>
+            </executions>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
 * before the change, "selenium" profile would overwite
   the failsafe config causing execution of only the
   seleinum based tests (others would be ignored). This
   change adds new failsafe execution that runs the selenium
   tests. It will be executed after the other smoke tests are
   ran.
 * by default Selenium tests are still disabled (no change here).
   One needs to enable 'selenium' profile to run them.

@jhrcek please take a look. The change effectively means that using `mvn clean install -Pkie-wb,tomcat7x,selenium` will run other smoke tests (REST, etc) as well, not just the selenium ones like so far. This should simplify execution of the tests in CI and also locally. I just want to make sure I did not overlook something.