### PR TITLE
Add JUnit Rule for taking screenshots on failed selenium test

### DIFF
--- a/kie-wb-smoke-tests/pom.xml
+++ b/kie-wb-smoke-tests/pom.xml
@@ -101,6 +101,10 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+    </dependency>
 
     <!--  Stay with httpcomponents: it will save us pain (as opposed to changing from resteasy to cxf to cxf 3.0, etc. --> 
     <dependency>
@@ -397,6 +401,10 @@
                 </goals>
                 <configuration>
                   <groups>org.kie.smoke.wb.category.KieWbSeleniumSmoke</groups>
+                  <systemPropertyVariables>
+                    <!-- directory where screenshots taken by webdriver will be placed -->
+                    <selenium.screenshots.dir>${project.build.directory}/screenshots</selenium.screenshots.dir>
+                  </systemPropertyVariables>
                 </configuration>
               </execution>
             </executions>

--- a/kie-wb-smoke-tests/src/main/java/org/kie/smoke/wb/selenium/model/KieSeleniumTest.java
+++ b/kie-wb-smoke-tests/src/main/java/org/kie/smoke/wb/selenium/model/KieSeleniumTest.java
@@ -17,13 +17,17 @@ package org.kie.smoke.wb.selenium.model;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.kie.smoke.wb.selenium.util.PageObjectFactory;
+import org.kie.smoke.wb.selenium.util.ScreenshotOnFailure;
 import org.openqa.selenium.WebDriver;
 
 public class KieSeleniumTest {
 
     protected static WebDriver driver;
     protected static PageObjectFactory pof;
+    @Rule
+    public ScreenshotOnFailure screenshotter = new ScreenshotOnFailure(driver);
 
     @BeforeClass
     public static void startWebDriver() {

--- a/kie-wb-smoke-tests/src/main/java/org/kie/smoke/wb/selenium/util/ScreenshotOnFailure.java
+++ b/kie-wb-smoke-tests/src/main/java/org/kie/smoke/wb/selenium/util/ScreenshotOnFailure.java
@@ -1,0 +1,75 @@
+package org.kie.smoke.wb.selenium.util;
+
+import java.io.File;
+import java.io.IOException;
+import org.apache.commons.io.FileUtils;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
+import org.openqa.selenium.OutputType;
+import org.openqa.selenium.TakesScreenshot;
+import org.openqa.selenium.WebDriver;
+
+/**
+ * JUnit Rule for taking screenshots/saving page HTML source of browser content
+ * on failed selenium test.
+ */
+public class ScreenshotOnFailure extends TestWatcher {
+
+    private final WebDriver driver;
+    private final File screenshotDir;
+
+    public ScreenshotOnFailure(WebDriver driver) {
+        this.driver = driver;
+        this.screenshotDir = initScreenshotDir();
+    }
+
+    @Override
+    protected void failed(Throwable e, Description description) {
+        String testClassName = description.getTestClass().getSimpleName();
+        String testMethodName = description.getMethodName();
+        String filename = testClassName + "_" + testMethodName;
+        takeScreenshot(filename);
+        savePageHtmlSource(filename);
+    }
+
+    private void takeScreenshot(String filename) {
+        File tmpScreenshot = ((TakesScreenshot) driver).getScreenshotAs(OutputType.FILE);
+        File targetScreenshot = new File(screenshotDir, filename + ".png");
+        try {
+            FileUtils.copyFile(tmpScreenshot, targetScreenshot);
+            System.out.println("Screenshot on failure taken: " + targetScreenshot);
+        } catch (IOException ex) {
+            System.err.print("Failed to take a screenshot on failed test " + filename + " " + ex.getMessage());
+        }
+    }
+
+    private void savePageHtmlSource(String filename) {
+        String pageSource = driver.getPageSource();
+        File targetFile = new File(screenshotDir, filename + ".html");
+        try {
+            FileUtils.writeStringToFile(targetFile, pageSource, "UTF-8");
+            System.out.println("Saved page HTML source on failure: " + targetFile);
+        } catch (IOException ex) {
+            System.err.println("Failed to save page HTML source " + ex.getMessage());
+        }
+    }
+
+    private File initScreenshotDir() {
+        String dir = System.getProperty("selenium.screenshots.dir");
+        if (dir == null) {
+            throw new IllegalStateException("Property selenium.screenshots.dir "
+                    + "(where screenshot taken by WebDriver will be put) must be defined: " + dir);
+        }
+        File scd = new File(dir);
+        if (!scd.exists()) {
+            boolean mkdirSuccess = scd.mkdir();
+            if (!mkdirSuccess) {
+                throw new IllegalStateException("Creation of screenshots dir failed " + scd);
+            }
+        }
+        if (!scd.canWrite()) {
+            throw new IllegalStateException("The screenshotDir must be writable" + scd);
+        }
+        return scd;
+    }
+}


### PR DESCRIPTION
This functionality is important for debugging selenium test (seeing what's displayed in the browser is often more informative than cryptic selenium messages). Also having page source proved useful for debugging.
This will come in handy when I add more comprehensive selenium smoke tests in the near future (traversing all perspectives and verifying they're loaded).