### PR TITLE
Selenium smoke traversing all perspectives

### DIFF
--- a/kie-wb-smoke-tests/src/main/java/org/kie/smoke/wb/selenium/model/KieSeleniumTest.java
+++ b/kie-wb-smoke-tests/src/main/java/org/kie/smoke/wb/selenium/model/KieSeleniumTest.java
@@ -29,9 +29,15 @@ public class KieSeleniumTest {
     @Rule
     public ScreenshotOnFailure screenshotter = new ScreenshotOnFailure(driver);
 
+    //Credentials based on from src/test/filtered-resources/eap-jbossas-wildfly-shared/config/application-users.properties
+    public final static String KIE_PASS = "mary123@";
+    public final static String KIE_USER = "mary";
+
     @BeforeClass
     public static void startWebDriver() {
         driver = WebDriverFactory.create();
+        driver.manage().window().maximize();
+
         pof = new PageObjectFactory(driver);
     }
 

--- a/kie-wb-smoke-tests/src/main/java/org/kie/smoke/wb/selenium/model/LoginPage.java
+++ b/kie-wb-smoke-tests/src/main/java/org/kie/smoke/wb/selenium/model/LoginPage.java
@@ -15,6 +15,7 @@
  */
 package org.kie.smoke.wb.selenium.model;
 
+import org.kie.smoke.wb.selenium.model.persps.HomePerspective;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
@@ -31,10 +32,10 @@ public class LoginPage extends PageObject {
 
     public LoginPage(WebDriver driver) {
         super(driver);
-        driver.get(BASE_URL);
     }
 
     public HomePerspective loginAs(String username, String password) {
+        driver.get(BASE_URL);
         submitCredentials(username, password);
         HomePerspective hp = new HomePerspective(driver);
         hp.waitForLoaded();

--- a/kie-wb-smoke-tests/src/main/java/org/kie/smoke/wb/selenium/model/Persp.java
+++ b/kie-wb-smoke-tests/src/main/java/org/kie/smoke/wb/selenium/model/Persp.java
@@ -1,0 +1,84 @@
+package org.kie.smoke.wb.selenium.model;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.kie.smoke.wb.selenium.model.persps.AbstractPerspective;
+import org.kie.smoke.wb.selenium.model.persps.AdministrationPerspective;
+import org.kie.smoke.wb.selenium.model.persps.AppsPerspective;
+import org.kie.smoke.wb.selenium.model.persps.ArtifactRepositoryPerspective;
+import org.kie.smoke.wb.selenium.model.persps.ContributorsPerspective;
+import org.kie.smoke.wb.selenium.model.persps.DataSetsPerspective;
+import org.kie.smoke.wb.selenium.model.persps.HomePerspective;
+import org.kie.smoke.wb.selenium.model.persps.JobsPerspective;
+import org.kie.smoke.wb.selenium.model.persps.PeoplePerspective;
+import org.kie.smoke.wb.selenium.model.persps.PluginManagementPerspective;
+import org.kie.smoke.wb.selenium.model.persps.ProcessAndTaskDashboardPerspective;
+import org.kie.smoke.wb.selenium.model.persps.ProcessDefinitionsPerspective;
+import org.kie.smoke.wb.selenium.model.persps.ProcessDeploymentsPerspective;
+import org.kie.smoke.wb.selenium.model.persps.ProcessInstancesPerspective;
+import org.kie.smoke.wb.selenium.model.persps.ProjectAuthoringPerspective;
+import org.kie.smoke.wb.selenium.model.persps.RuleDeploymentsPerspective;
+import org.kie.smoke.wb.selenium.model.persps.TasksPerspective;
+import org.kie.smoke.wb.selenium.model.persps.TimelinePerspective;
+
+public class Persp<T extends AbstractPerspective> {
+
+    public static final Persp<HomePerspective> HOME_PAGE = new Persp<HomePerspective>("Home", "Home Page", HomePerspective.class);
+    public static final Persp<TimelinePerspective> TIMELINE = new Persp<TimelinePerspective>("Home", "Timeline", TimelinePerspective.class);
+    public static final Persp<PeoplePerspective> PEOPLE = new Persp<PeoplePerspective>("Home", "People", PeoplePerspective.class);
+    public static final Persp<ProjectAuthoringPerspective> PROJECT_AUTHORING = new Persp<ProjectAuthoringPerspective>("Authoring", "Project Authoring", ProjectAuthoringPerspective.class);
+    public static final Persp<ContributorsPerspective> CONTRIBUTORS = new Persp<ContributorsPerspective>("Authoring", "Contributors", ContributorsPerspective.class);
+    public static final Persp<ArtifactRepositoryPerspective> ARTIFACT_REPOSITORY = new Persp<ArtifactRepositoryPerspective>("Authoring", "Artifact repository", ArtifactRepositoryPerspective.class);
+    public static final Persp<AdministrationPerspective> ADMINISTRATION = new Persp<AdministrationPerspective>("Authoring", "Administration", AdministrationPerspective.class);
+    public static final Persp<ProcessDeploymentsPerspective> PROCESS_DEPLOYMENTS = new Persp<ProcessDeploymentsPerspective>("Deploy", "Process Deployments", ProcessDeploymentsPerspective.class);
+    public static final Persp<RuleDeploymentsPerspective> RULE_DEPLOYMENTS = new Persp<RuleDeploymentsPerspective>("Deploy", "Rule Deployments", RuleDeploymentsPerspective.class);
+    public static final Persp<JobsPerspective> JOBS = new Persp<JobsPerspective>("Deploy", "Jobs", JobsPerspective.class);
+    public static final Persp<ProcessDefinitionsPerspective> PROCESS_DEFINITIONS = new Persp<ProcessDefinitionsPerspective>("Process Management", "Process Definitions", ProcessDefinitionsPerspective.class);
+    public static final Persp<ProcessInstancesPerspective> PROCESS_INSTANCES = new Persp<ProcessInstancesPerspective>("Process Management", "Process Instances", ProcessInstancesPerspective.class);
+    public static final Persp<TasksPerspective> TASKS = new Persp<TasksPerspective>("N/A", "N/A", TasksPerspective.class);
+    public static final Persp<ProcessAndTaskDashboardPerspective> PROCESS_AND_TASK_DASHBOARD = new Persp<ProcessAndTaskDashboardPerspective>("Dashboards", "Process & Task Dashboard", ProcessAndTaskDashboardPerspective.class);
+    public static final Persp<PluginManagementPerspective> PLUGIN_MANAGEMENT = new Persp<PluginManagementPerspective>("Extensions", "PlugIn Management", PluginManagementPerspective.class);
+    public static final Persp<AppsPerspective> APPS = new Persp<AppsPerspective>("Extensions", "Apps", AppsPerspective.class);
+    public static final Persp<DataSetsPerspective> DATA_SETS = new Persp<DataSetsPerspective>("Extensions", "Data Sets", DataSetsPerspective.class);
+
+    private static final List<Persp<? extends AbstractPerspective>> ALL_PERSPS = Collections.unmodifiableList(Arrays.asList(
+            HOME_PAGE, TIMELINE, PEOPLE, PROJECT_AUTHORING, CONTRIBUTORS, ARTIFACT_REPOSITORY, ADMINISTRATION,
+            PROCESS_DEPLOYMENTS, RULE_DEPLOYMENTS, JOBS, PROCESS_DEFINITIONS, PROCESS_INSTANCES, TASKS,
+            PROCESS_AND_TASK_DASHBOARD, PLUGIN_MANAGEMENT, APPS, DATA_SETS
+    ));
+
+    public static List<Persp<? extends AbstractPerspective>> getAllPerspectives() {
+        return ALL_PERSPS;
+    }
+
+    private final String parentMenu;
+    private final String menuItem;
+    private final Class<T> perspPageObjectClass;
+
+    private Persp(String parentMenu, String menuItem, Class<T> perspPageObjectClass) {
+        this.parentMenu = parentMenu;
+        this.menuItem = menuItem;
+        this.perspPageObjectClass = perspPageObjectClass;
+    }
+
+    public String getMenu() {
+        return parentMenu;
+    }
+
+    public String getName() {
+        return menuItem;
+    }
+
+    public Class<T> getPerspectivePageObjectClass() {
+        return perspPageObjectClass;
+    }
+
+    /**
+     * @return String used to identify parametrized testcases.
+     */
+    @Override
+    public String toString() {
+        return getName().replace(' ', '_');
+    }
+}

--- a/kie-wb-smoke-tests/src/main/java/org/kie/smoke/wb/selenium/model/PrimaryNavbar.java
+++ b/kie-wb-smoke-tests/src/main/java/org/kie/smoke/wb/selenium/model/PrimaryNavbar.java
@@ -14,21 +14,129 @@ package org.kie.smoke.wb.selenium.model;
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import org.kie.smoke.wb.selenium.model.persps.AbstractPerspective;
+import org.kie.smoke.wb.selenium.model.persps.AdministrationPerspective;
+import org.kie.smoke.wb.selenium.model.persps.AppsPerspective;
+import org.kie.smoke.wb.selenium.model.persps.ArtifactRepositoryPerspective;
+import org.kie.smoke.wb.selenium.model.persps.ContributorsPerspective;
+import org.kie.smoke.wb.selenium.model.persps.DataSetsPerspective;
+import org.kie.smoke.wb.selenium.model.persps.HomePerspective;
+import org.kie.smoke.wb.selenium.model.persps.JobsPerspective;
+import org.kie.smoke.wb.selenium.model.persps.PeoplePerspective;
+import org.kie.smoke.wb.selenium.model.persps.PluginManagementPerspective;
+import org.kie.smoke.wb.selenium.model.persps.ProcessAndTaskDashboardPerspective;
+import org.kie.smoke.wb.selenium.model.persps.ProcessDefinitionsPerspective;
+import org.kie.smoke.wb.selenium.model.persps.ProcessDeploymentsPerspective;
+import org.kie.smoke.wb.selenium.model.persps.ProcessInstancesPerspective;
+import org.kie.smoke.wb.selenium.model.persps.ProjectAuthoringPerspective;
+import org.kie.smoke.wb.selenium.model.persps.RuleDeploymentsPerspective;
+import org.kie.smoke.wb.selenium.model.persps.TasksPerspective;
+import org.kie.smoke.wb.selenium.model.persps.TimelinePerspective;
 import static org.kie.smoke.wb.selenium.util.ByUtil.xpath;
 
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+import org.openqa.selenium.support.PageFactory;
 
 public class PrimaryNavbar extends PageObject {
 
     private static final String NAV_MENU //Contains both the link to expand menu as well as menu item links
-            = "//nav//li[@class='dropdown'][a[contains(text(),'%s')]]";
-    private static final By LOGOUT_MENU // Unlike other navbar menus this has no stable link text
-            = By.cssSelector("li[title='Reset all Perspective layouts']+li");
+            = "//nav//li[contains(@class,'dropdown')][a[contains(text(),'%s')]]";
+
+    @FindBy(css = "li[title='Reset all Perspective layouts']+li")
+    private WebElement logoutMenu;
 
     public PrimaryNavbar(WebDriver driver) {
         super(driver);
+    }
+
+    public void logout() {
+        //Logou menu has no stable title (just username)
+        logoutMenu.findElement(By.tagName("a")).click();
+        selectItem(logoutMenu, "Log Out");
+    }
+
+    public HomePerspective homePage() {
+        return navigateTo(Persp.HOME_PAGE);
+    }
+
+    public TimelinePerspective timeline() {
+        return navigateTo(Persp.TIMELINE);
+    }
+
+    public PeoplePerspective people() {
+        return navigateTo(Persp.PEOPLE);
+    }
+
+    public ProjectAuthoringPerspective projectAuthoring() {
+        return navigateTo(Persp.PROJECT_AUTHORING);
+    }
+
+    public ContributorsPerspective contributors() {
+        return navigateTo(Persp.CONTRIBUTORS);
+    }
+
+    public ArtifactRepositoryPerspective artifactRepository() {
+        return navigateTo(Persp.ARTIFACT_REPOSITORY);
+    }
+
+    public AdministrationPerspective administration() {
+        return navigateTo(Persp.ADMINISTRATION);
+    }
+
+    public ProcessDeploymentsPerspective processDeployments() {
+        return navigateTo(Persp.PROCESS_DEPLOYMENTS);
+    }
+
+    public RuleDeploymentsPerspective ruleDeployments() {
+        return navigateTo(Persp.RULE_DEPLOYMENTS);
+    }
+
+    public JobsPerspective jobs() {
+        return navigateTo(Persp.JOBS);
+    }
+
+    public ProcessDefinitionsPerspective processDefinitions() {
+        return navigateTo(Persp.PROCESS_DEFINITIONS);
+    }
+
+    public ProcessInstancesPerspective processInstances() {
+        return navigateTo(Persp.PROCESS_INSTANCES);
+    }
+
+    public TasksPerspective tasks() {
+        return navigateTo(Persp.TASKS);
+    }
+
+    public ProcessAndTaskDashboardPerspective processAndTaskDashboard() {
+        return navigateTo(Persp.PROCESS_AND_TASK_DASHBOARD);
+    }
+
+    public PluginManagementPerspective pluginManagement() {
+        return navigateTo(Persp.PLUGIN_MANAGEMENT);
+    }
+
+    public AppsPerspective apps() {
+        return navigateTo(Persp.APPS);
+    }
+
+    public DataSetsPerspective dataSets() {
+        return navigateTo(Persp.DATA_SETS);
+    }
+
+    public <T extends AbstractPerspective> T navigateTo(Persp<T> p) {
+        if (p == Persp.TASKS) {
+            //Tasks is not a menu, just a link
+            driver.findElement(By.linkText("Tasks")).click();
+        } else {
+            WebElement menu = openMenu(p.getMenu());
+            selectItem(menu, p.getName());
+        }
+        T perspective = PageFactory.initElements(driver, p.getPerspectivePageObjectClass());
+        perspective.waitForLoaded();
+        return perspective;
     }
 
     private WebElement openMenu(String menuTitle) {
@@ -41,17 +149,4 @@ public class PrimaryNavbar extends PageObject {
         WebElement menuItem = openedMenu.findElement(By.linkText(itemText));
         menuItem.click();
     }
-
-    public void logout() {
-        WebElement menu = driver.findElement(LOGOUT_MENU);
-        menu.findElement(By.tagName("a")).click();
-        selectItem(menu, "Log Out");
-    }
-
-    public void projectAuthoring() {
-        WebElement menu = openMenu("Authoring");
-        selectItem(menu, "Project Authoring");
-    }
-
-    //TODO all items to navigate to other perspectivesS
 }

--- a/kie-wb-smoke-tests/src/main/java/org/kie/smoke/wb/selenium/model/persps/AbstractPerspective.java
+++ b/kie-wb-smoke-tests/src/main/java/org/kie/smoke/wb/selenium/model/persps/AbstractPerspective.java
@@ -13,37 +13,35 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.kie.smoke.wb.selenium.model;
+package org.kie.smoke.wb.selenium.model.persps;
 
+import org.kie.smoke.wb.selenium.model.LoginPage;
+import org.kie.smoke.wb.selenium.model.PageObject;
+import org.kie.smoke.wb.selenium.model.PrimaryNavbar;
 import org.kie.smoke.wb.selenium.util.PageObjectFactory;
 import org.kie.smoke.wb.selenium.util.Waits;
 import org.openqa.selenium.By;
-import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.PageFactory;
 
-public class HomePerspective extends PageObject {
+public abstract class AbstractPerspective extends PageObject {
 
     private final PrimaryNavbar navbar;
-    private static final By CAROUSEL = By.className("carousel-caption");
 
-    public HomePerspective(WebDriver driver) {
+    public AbstractPerspective(WebDriver driver) {
         super(driver);
         navbar = PageFactory.initElements(driver, PrimaryNavbar.class);
     }
 
-    public void waitForLoaded() {
-        Waits.elementPresent(driver, CAROUSEL);
+    public PrimaryNavbar getNavbar() {
+        return navbar;
     }
 
-    public boolean isDisplayed() {
-        try {
-            Waits.elementPresent(driver, CAROUSEL, 2);
-            return true;
-        } catch (NoSuchElementException nse) {
-            return false;
-        }
+    /**
+     * Waiting for the perspective to be fully loaded. No-op by default.
+     */
+    public void waitForLoaded() {
     }
 
     public LoginPage logout() {
@@ -53,4 +51,6 @@ public class HomePerspective extends PageObject {
         loginAgainButton.click();
         return new PageObjectFactory(driver).createLoginPage();
     }
+
+    public abstract boolean isDisplayed();
 }

--- a/kie-wb-smoke-tests/src/main/java/org/kie/smoke/wb/selenium/model/persps/AdministrationPerspective.java
+++ b/kie-wb-smoke-tests/src/main/java/org/kie/smoke/wb/selenium/model/persps/AdministrationPerspective.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2015 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.smoke.wb.selenium.model.persps;
+
+import org.kie.smoke.wb.selenium.util.Waits;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+
+public class AdministrationPerspective extends AbstractPerspective {
+
+    private static final By REPOSITORY_EDITOR_TITLE = By.cssSelector("span[title='RepositoryEditor']");
+    private static final By FILE_EXPLORER_CONTENT = By.cssSelector(" .fa-folder,.fa-folder-open");
+
+    public AdministrationPerspective(WebDriver driver) {
+        super(driver);
+    }
+
+    @Override
+    public void waitForLoaded() {
+        Waits.elementPresent(driver, FILE_EXPLORER_CONTENT);
+        Waits.pause(1000);
+    }
+
+    @Override
+    public boolean isDisplayed() {
+        return Waits.isElementPresent(driver, REPOSITORY_EDITOR_TITLE);
+    }
+}

--- a/kie-wb-smoke-tests/src/main/java/org/kie/smoke/wb/selenium/model/persps/AppsPerspective.java
+++ b/kie-wb-smoke-tests/src/main/java/org/kie/smoke/wb/selenium/model/persps/AppsPerspective.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2015 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.smoke.wb.selenium.model.persps;
+
+import org.kie.smoke.wb.selenium.util.Waits;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+
+public class AppsPerspective extends AbstractPerspective {
+
+    private static final By HOME_LINK = By.linkText("home");
+
+    public AppsPerspective(WebDriver driver) {
+        super(driver);
+    }
+
+    @Override
+    public boolean isDisplayed() {
+        return Waits.isElementPresent(driver, HOME_LINK);
+    }
+}

--- a/kie-wb-smoke-tests/src/main/java/org/kie/smoke/wb/selenium/model/persps/ArtifactRepositoryPerspective.java
+++ b/kie-wb-smoke-tests/src/main/java/org/kie/smoke/wb/selenium/model/persps/ArtifactRepositoryPerspective.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2015 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.smoke.wb.selenium.model.persps;
+
+import org.kie.smoke.wb.selenium.util.Waits;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+
+public class ArtifactRepositoryPerspective extends AbstractPerspective {
+
+    private static final By NAME_COLUMN_HEADER = By.xpath("//th[contains(text(),'Name')]");
+
+    public ArtifactRepositoryPerspective(WebDriver driver) {
+        super(driver);
+    }
+
+    @Override
+    public boolean isDisplayed() {
+        return Waits.isElementPresent(driver, NAME_COLUMN_HEADER);
+    }
+}

--- a/kie-wb-smoke-tests/src/main/java/org/kie/smoke/wb/selenium/model/persps/ContributorsPerspective.java
+++ b/kie-wb-smoke-tests/src/main/java/org/kie/smoke/wb/selenium/model/persps/ContributorsPerspective.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2015 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.smoke.wb.selenium.model.persps;
+
+import org.kie.smoke.wb.selenium.util.Waits;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+
+public class ContributorsPerspective extends AbstractPerspective {
+
+    private static final By CHART_TITLE = By.xpath("//div[contains(text(), 'Commits per organizational unit')]");
+
+    public ContributorsPerspective(WebDriver driver) {
+        super(driver);
+    }
+
+    @Override
+    public boolean isDisplayed() {
+        return Waits.isElementPresent(driver, CHART_TITLE);
+    }
+}

--- a/kie-wb-smoke-tests/src/main/java/org/kie/smoke/wb/selenium/model/persps/DataSetsPerspective.java
+++ b/kie-wb-smoke-tests/src/main/java/org/kie/smoke/wb/selenium/model/persps/DataSetsPerspective.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2015 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.smoke.wb.selenium.model.persps;
+
+import org.kie.smoke.wb.selenium.util.Waits;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+
+public class DataSetsPerspective extends AbstractPerspective {
+
+    private static final By NEW_DS_LINK = By.linkText("new data set");
+
+    public DataSetsPerspective(WebDriver driver) {
+        super(driver);
+    }
+
+    @Override
+    public boolean isDisplayed() {
+        return Waits.isElementPresent(driver, NEW_DS_LINK);
+    }
+}

--- a/kie-wb-smoke-tests/src/main/java/org/kie/smoke/wb/selenium/model/persps/HomePerspective.java
+++ b/kie-wb-smoke-tests/src/main/java/org/kie/smoke/wb/selenium/model/persps/HomePerspective.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2015 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.smoke.wb.selenium.model.persps;
+
+import org.kie.smoke.wb.selenium.util.Waits;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+
+public class HomePerspective extends AbstractPerspective {
+
+    private static final By CAROUSEL = By.className("carousel-caption");
+
+    public HomePerspective(WebDriver driver) {
+        super(driver);
+    }
+
+    @Override
+    public void waitForLoaded() {
+        Waits.elementPresent(driver, CAROUSEL);
+    }
+
+    @Override
+    public boolean isDisplayed() {
+        return Waits.isElementPresent(driver, CAROUSEL);
+    }
+}

--- a/kie-wb-smoke-tests/src/main/java/org/kie/smoke/wb/selenium/model/persps/JobsPerspective.java
+++ b/kie-wb-smoke-tests/src/main/java/org/kie/smoke/wb/selenium/model/persps/JobsPerspective.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2015 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.smoke.wb.selenium.model.persps;
+
+import org.kie.smoke.wb.selenium.util.Waits;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+
+public class JobsPerspective extends AbstractPerspective {
+
+    private static final By ID_COLUMN_HEADER = By.xpath("//th[contains(text(), 'Id')]");
+
+    public JobsPerspective(WebDriver driver) {
+        super(driver);
+    }
+
+    @Override
+    public boolean isDisplayed() {
+        return Waits.isElementPresent(driver, ID_COLUMN_HEADER);
+    }
+}

--- a/kie-wb-smoke-tests/src/main/java/org/kie/smoke/wb/selenium/model/persps/PeoplePerspective.java
+++ b/kie-wb-smoke-tests/src/main/java/org/kie/smoke/wb/selenium/model/persps/PeoplePerspective.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2015 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.smoke.wb.selenium.model.persps;
+
+import org.kie.smoke.wb.selenium.util.Waits;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+
+public class PeoplePerspective extends AbstractPerspective {
+
+    private static final By PROFILE_HOME_BUTTON = By.cssSelector("button[title=\"Go To User's Home\"]");
+
+    public PeoplePerspective(WebDriver driver) {
+        super(driver);
+    }
+
+    @Override
+    public boolean isDisplayed() {
+        return Waits.isElementPresent(driver, PROFILE_HOME_BUTTON);
+    }
+}

--- a/kie-wb-smoke-tests/src/main/java/org/kie/smoke/wb/selenium/model/persps/PluginManagementPerspective.java
+++ b/kie-wb-smoke-tests/src/main/java/org/kie/smoke/wb/selenium/model/persps/PluginManagementPerspective.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2015 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.smoke.wb.selenium.model.persps;
+
+import org.kie.smoke.wb.selenium.util.Waits;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+
+public class PluginManagementPerspective extends AbstractPerspective {
+
+    private static final By PLUGINS_EXPLORER_TITLE = By.xpath("//span[contains(text(),'Plugins')]");
+
+    public PluginManagementPerspective(WebDriver driver) {
+        super(driver);
+    }
+
+    @Override
+    public boolean isDisplayed() {
+        return Waits.isElementPresent(driver, PLUGINS_EXPLORER_TITLE);
+    }
+}

--- a/kie-wb-smoke-tests/src/main/java/org/kie/smoke/wb/selenium/model/persps/ProcessAndTaskDashboardPerspective.java
+++ b/kie-wb-smoke-tests/src/main/java/org/kie/smoke/wb/selenium/model/persps/ProcessAndTaskDashboardPerspective.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2015 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.smoke.wb.selenium.model.persps;
+
+import org.kie.smoke.wb.selenium.util.Waits;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+
+public class ProcessAndTaskDashboardPerspective extends AbstractPerspective {
+
+    private static final By PROCESSES_TAB = By.id("processes");
+
+    public ProcessAndTaskDashboardPerspective(WebDriver driver) {
+        super(driver);
+    }
+
+    @Override
+    public boolean isDisplayed() {
+        return Waits.isElementPresent(driver, PROCESSES_TAB);
+    }
+}

--- a/kie-wb-smoke-tests/src/main/java/org/kie/smoke/wb/selenium/model/persps/ProcessDefinitionsPerspective.java
+++ b/kie-wb-smoke-tests/src/main/java/org/kie/smoke/wb/selenium/model/persps/ProcessDefinitionsPerspective.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2015 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.smoke.wb.selenium.model.persps;
+
+import org.kie.smoke.wb.selenium.util.Waits;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+
+public class ProcessDefinitionsPerspective extends AbstractPerspective {
+
+    private static final By PROC_DEFS_TITLE = By.cssSelector("span[title='Process Definitions']");
+
+    public ProcessDefinitionsPerspective(WebDriver driver) {
+        super(driver);
+    }
+
+    @Override
+    public boolean isDisplayed() {
+        return Waits.isElementPresent(driver, PROC_DEFS_TITLE);
+    }
+}

--- a/kie-wb-smoke-tests/src/main/java/org/kie/smoke/wb/selenium/model/persps/ProcessDeploymentsPerspective.java
+++ b/kie-wb-smoke-tests/src/main/java/org/kie/smoke/wb/selenium/model/persps/ProcessDeploymentsPerspective.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2015 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.smoke.wb.selenium.model.persps;
+
+import org.kie.smoke.wb.selenium.util.Waits;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+
+public class ProcessDeploymentsPerspective extends AbstractPerspective {
+
+    private static final By PROC_DEPLS_TITLE = By.cssSelector("span[title='Deployed Units']");
+
+    public ProcessDeploymentsPerspective(WebDriver driver) {
+        super(driver);
+    }
+
+    @Override
+    public boolean isDisplayed() {
+        return Waits.isElementPresent(driver, PROC_DEPLS_TITLE);
+    }
+}

--- a/kie-wb-smoke-tests/src/main/java/org/kie/smoke/wb/selenium/model/persps/ProcessInstancesPerspective.java
+++ b/kie-wb-smoke-tests/src/main/java/org/kie/smoke/wb/selenium/model/persps/ProcessInstancesPerspective.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2015 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.smoke.wb.selenium.model.persps;
+
+import org.kie.smoke.wb.selenium.util.Waits;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+
+public class ProcessInstancesPerspective extends AbstractPerspective {
+
+    private static final By PROC_INST_TITLE = By.cssSelector("span[title='Process Instances']");
+
+    public ProcessInstancesPerspective(WebDriver driver) {
+        super(driver);
+    }
+
+    @Override
+    public boolean isDisplayed() {
+        return Waits.isElementPresent(driver, PROC_INST_TITLE);
+    }
+}

--- a/kie-wb-smoke-tests/src/main/java/org/kie/smoke/wb/selenium/model/persps/ProjectAuthoringPerspective.java
+++ b/kie-wb-smoke-tests/src/main/java/org/kie/smoke/wb/selenium/model/persps/ProjectAuthoringPerspective.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2015 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.smoke.wb.selenium.model.persps;
+
+import org.kie.smoke.wb.selenium.util.Waits;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+
+public class ProjectAuthoringPerspective extends AbstractPerspective {
+
+    private static final By PROJECT_EXPLORER_TITLE = By.xpath("//h3[contains(text(),'Project Explorer')]");
+    //Project explorer bradcrumb toggle, whose presence indicates that PEX content has been loaded
+    private static final By PEX_BREADCRUMB_TOGGLE = By.cssSelector(".fa-chevron-down");
+
+    public ProjectAuthoringPerspective(WebDriver driver) {
+        super(driver);
+    }
+
+    @Override
+    public void waitForLoaded() {
+        Waits.elementPresent(driver, PEX_BREADCRUMB_TOGGLE, 10);
+    }
+
+    @Override
+    public boolean isDisplayed() {
+        return Waits.isElementPresent(driver, PROJECT_EXPLORER_TITLE);
+    }
+}

--- a/kie-wb-smoke-tests/src/main/java/org/kie/smoke/wb/selenium/model/persps/RuleDeploymentsPerspective.java
+++ b/kie-wb-smoke-tests/src/main/java/org/kie/smoke/wb/selenium/model/persps/RuleDeploymentsPerspective.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2015 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.smoke.wb.selenium.model.persps;
+
+import org.kie.smoke.wb.selenium.util.Waits;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+
+public class RuleDeploymentsPerspective extends AbstractPerspective {
+
+    private static final By SERVER_MGMT_TITLE = By.cssSelector("span[title='Server Management Browser']");
+
+    public RuleDeploymentsPerspective(WebDriver driver) {
+        super(driver);
+    }
+
+    @Override
+    public boolean isDisplayed() {
+        return Waits.isElementPresent(driver, SERVER_MGMT_TITLE);
+    }
+}

--- a/kie-wb-smoke-tests/src/main/java/org/kie/smoke/wb/selenium/model/persps/TasksPerspective.java
+++ b/kie-wb-smoke-tests/src/main/java/org/kie/smoke/wb/selenium/model/persps/TasksPerspective.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2015 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.smoke.wb.selenium.model.persps;
+
+import org.kie.smoke.wb.selenium.util.Waits;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+
+public class TasksPerspective extends AbstractPerspective {
+
+    private static final By ACTIVE_FILTER_TITLE = By.xpath("//h4[contains(text(),'Filter Active')]");
+
+    public TasksPerspective(WebDriver driver) {
+        super(driver);
+    }
+
+    @Override
+    public boolean isDisplayed() {
+        return Waits.isElementPresent(driver, ACTIVE_FILTER_TITLE);
+    }
+}

--- a/kie-wb-smoke-tests/src/main/java/org/kie/smoke/wb/selenium/model/persps/TimelinePerspective.java
+++ b/kie-wb-smoke-tests/src/main/java/org/kie/smoke/wb/selenium/model/persps/TimelinePerspective.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2015 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.smoke.wb.selenium.model.persps;
+
+import org.kie.smoke.wb.selenium.util.Waits;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+
+public class TimelinePerspective extends AbstractPerspective {
+
+    private static final By LATEST_CHANGES_TITLE = By.cssSelector("span[title='Latest Changes']");
+
+    public TimelinePerspective(WebDriver driver) {
+        super(driver);
+    }
+
+    @Override
+    public boolean isDisplayed() {
+        return Waits.isElementPresent(driver, LATEST_CHANGES_TITLE);
+    }
+}

--- a/kie-wb-smoke-tests/src/main/java/org/kie/smoke/wb/selenium/util/PageObjectFactory.java
+++ b/kie-wb-smoke-tests/src/main/java/org/kie/smoke/wb/selenium/util/PageObjectFactory.java
@@ -21,7 +21,8 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.support.PageFactory;
 
 /**
- * Utility for creating page objects without having to explicitly manipulate WebDriver.
+ * Utility for creating page objects without having to explicitly manipulate
+ * WebDriver.
  */
 public class PageObjectFactory {
 

--- a/kie-wb-smoke-tests/src/main/java/org/kie/smoke/wb/selenium/util/Waits.java
+++ b/kie-wb-smoke-tests/src/main/java/org/kie/smoke/wb/selenium/util/Waits.java
@@ -16,6 +16,7 @@
 package org.kie.smoke.wb.selenium.util;
 
 import org.openqa.selenium.By;
+import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
@@ -25,19 +26,41 @@ public class Waits {
 
     private static final int DEFAULT_TIMEOUT = 15;
 
-    public static WebElement elementPresent(WebDriver driver, By element, int timeoutSeconds) {
+    public static void elementVisible(WebDriver driver, By locator, int timeoutSeconds) {
+        new WebDriverWait(driver, timeoutSeconds)
+                .until(ExpectedConditions.visibilityOfElementLocated(locator));
+    }
+
+    public static WebElement elementPresent(WebDriver driver, By locator, int timeoutSeconds) {
         WebElement elementPresent = new WebDriverWait(driver, timeoutSeconds)
-                .until(ExpectedConditions.presenceOfElementLocated(element));
+                .until(ExpectedConditions.presenceOfElementLocated(locator));
         return elementPresent;
     }
 
-    public static WebElement elementPresent(WebDriver driver, By element) {
-        return elementPresent(driver, element, DEFAULT_TIMEOUT);
+    public static WebElement elementPresent(WebDriver driver, By locator) {
+        return elementPresent(driver, locator, DEFAULT_TIMEOUT);
     }
 
-    public static WebElement elementClickable(WebDriver driver, By element) {
+    public static WebElement elementClickable(WebDriver driver, By locator) {
         WebElement clickableElement = new WebDriverWait(driver, DEFAULT_TIMEOUT)
-                .until(ExpectedConditions.elementToBeClickable(element));
+                .until(ExpectedConditions.elementToBeClickable(locator));
         return clickableElement;
+    }
+
+    public static boolean isElementPresent(WebDriver driver, By locator) {
+        try {
+            elementPresent(driver, locator);
+            return true;
+        } catch (NoSuchElementException nse) {
+            return false;
+        }
+    }
+
+    public static void pause(int miliseconds) {
+        try {
+            Thread.sleep(miliseconds);
+        } catch (InterruptedException ex) {
+            System.err.println("Pause interrupted");
+        }
     }
 }

--- a/kie-wb-smoke-tests/src/test/java/org/kie/smoke/wb/selenium/ui/LoadAllPerspectivesIntegrationTest.java
+++ b/kie-wb-smoke-tests/src/test/java/org/kie/smoke/wb/selenium/ui/LoadAllPerspectivesIntegrationTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2015 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.smoke.wb.selenium.ui;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.AfterClass;
+import static org.junit.Assert.assertTrue;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+import org.kie.smoke.wb.category.KieWbSeleniumSmoke;
+import org.kie.smoke.wb.selenium.model.KieSeleniumTest;
+import org.kie.smoke.wb.selenium.model.LoginPage;
+import org.kie.smoke.wb.selenium.model.Persp;
+import org.kie.smoke.wb.selenium.model.PrimaryNavbar;
+import org.kie.smoke.wb.selenium.model.persps.AbstractPerspective;
+
+/**
+ * Login and verify each perspective can be navigated to and loads some content.
+ */
+@RunWith(Parameterized.class)
+@Category(KieWbSeleniumSmoke.class)
+public class LoadAllPerspectivesIntegrationTest extends KieSeleniumTest {
+
+    private static PrimaryNavbar navbar;
+    private final Persp<?> persp;
+
+    public LoadAllPerspectivesIntegrationTest(Persp<?> persp) {
+        this.persp = persp;
+    }
+
+    @Parameters(name = "{0}")
+    public static List<Object[]> perspectives() {
+        List<Object[]> params = new ArrayList<Object[]>();
+        for (Persp<?> p : Persp.getAllPerspectives()) {
+            params.add(new Object[]{p});
+        }
+        return params;
+    }
+
+    @BeforeClass
+    public static void login() {
+        LoginPage lp = pof.createLoginPage();
+        navbar = lp.loginAs(KIE_USER, KIE_PASS).getNavbar();
+    }
+
+    @AfterClass
+    public static void logout() {
+        navbar.logout();
+    }
+
+    @Test
+    public void checkPerspectiveLoaded() {
+        AbstractPerspective perspective = navbar.navigateTo(persp);
+        assertTrue("Perspective " + persp.getName() + " should be loaded", perspective.isDisplayed());
+    }
+}

--- a/kie-wb-smoke-tests/src/test/java/org/kie/smoke/wb/selenium/ui/LoginIntegrationTest.java
+++ b/kie-wb-smoke-tests/src/test/java/org/kie/smoke/wb/selenium/ui/LoginIntegrationTest.java
@@ -14,24 +14,19 @@
  */
 package org.kie.smoke.wb.selenium.ui;
 
-import static org.junit.Assert.assertTrue;
-
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.kie.smoke.wb.category.KieWbSeleniumSmoke;
-import org.kie.smoke.wb.selenium.model.HomePerspective;
+import org.kie.smoke.wb.selenium.model.persps.HomePerspective;
 import org.kie.smoke.wb.selenium.model.KieSeleniumTest;
 import org.kie.smoke.wb.selenium.model.LoginPage;
+import static org.junit.Assert.assertTrue;
 
 @Category(KieWbSeleniumSmoke.class)
 public class LoginIntegrationTest extends KieSeleniumTest {
 
-    //Credentials based on from src/test/filtered-resources/eap-jbossas-wildfly-shared/config/application-users.properties
-    public final static String KIE_PASS = "mary123@";
-    public final static String KIE_USER = "mary";
-
     @Test
-    public void loginAndLogout() throws Exception {
+    public void loginAndLogout() {
         LoginPage login = pof.createLoginPage();
 
         HomePerspective home = login.loginAs(KIE_USER, KIE_PASS);


### PR DESCRIPTION
Ready for review / merge.

UPDATE1: each perspective now tested in separate parametrized test.
UPDATE2: 1) extra wait for authoring persp. to load 2) maximize browser widnow on test start
UPDATE3: Name parametrized testcases based on perspective being tested
UPDATE4: After weekend of running tests there are 1-2 of 17 tests failing. 100% of fails are caused by either Authoring / Administration perspectives not being loaded (thus navigation to Contributors / Project Deployments perspectives was failing most of the time). Added explicit wait for those 2 perspectives to load
UPDATE5: Repeated smoke execution on jenkins confirmed that we've reached sufficient level of stability (20 successive runs without fails on IE).