### PR TITLE
Don't smoke test some perspectives when running agains kie-drools-wb

### DIFF
--- a/kie-wb-smoke-tests/kie-wb-smoke-tests-main/pom.xml
+++ b/kie-wb-smoke-tests/kie-wb-smoke-tests-main/pom.xml
@@ -13,6 +13,10 @@
   <name>KIE (Drools) Workbench Smoke Tests :: Main</name>
   <description>Integration smoke tests for KIE Workbench and KIE Drools Workbench</description>
 
+  <properties>
+    <app.name>kie-wb</app.name><!-- for tests to know if they are running against kie-wb or kie-drools-wb -->
+  </properties>
+  
   <dependencies>
     <!-- utilities -->
     <dependency>
@@ -275,6 +279,7 @@
         <deployable.groupId>org.kie</deployable.groupId>
         <deployable.artifactId>kie-drools-wb-distribution-wars</deployable.artifactId>
         <deployable.context>kie-drools-wb</deployable.context>
+        <app.name>kie-drools-wb</app.name>
       </properties>
       <build>
         <pluginManagement>
@@ -348,6 +353,7 @@
                   <systemPropertyVariables>
                     <!-- directory where screenshots taken by webdriver will be placed -->
                     <selenium.screenshots.dir>${project.build.directory}/screenshots</selenium.screenshots.dir>
+                    <app.name>${app.name}</app.name>
                   </systemPropertyVariables>
                 </configuration>
               </execution>

--- a/kie-wb-smoke-tests/kie-wb-smoke-tests-main/src/main/java/org/kie/smoke/wb/selenium/model/KieSeleniumTest.java
+++ b/kie-wb-smoke-tests/kie-wb-smoke-tests-main/src/main/java/org/kie/smoke/wb/selenium/model/KieSeleniumTest.java
@@ -26,6 +26,8 @@ public class KieSeleniumTest {
 
     protected static WebDriver driver;
     protected static PageObjectFactory pof;
+    public static final boolean isKieWb = isKieWb();
+
     @Rule
     public ScreenshotOnFailure screenshotter = new ScreenshotOnFailure(driver);
 
@@ -46,5 +48,13 @@ public class KieSeleniumTest {
         if (driver != null) {
             driver.quit();
         }
+    }
+
+    private static boolean isKieWb() {
+        String prop = System.getProperty("app.name");
+        if (!("kie-wb".equals(prop) || "kie-drools-wb".equals(prop))) {
+            throw new IllegalStateException("Invalid app.name='" + prop + "' Expecting kie-wb or kie-drools-wb");
+        }
+        return "kie-wb".equals(prop);
     }
 }

--- a/kie-wb-smoke-tests/kie-wb-smoke-tests-main/src/main/java/org/kie/smoke/wb/selenium/model/Persp.java
+++ b/kie-wb-smoke-tests/kie-wb-smoke-tests-main/src/main/java/org/kie/smoke/wb/selenium/model/Persp.java
@@ -39,23 +39,56 @@ import org.kie.smoke.wb.selenium.model.persps.TimelinePerspective;
 
 public class Persp<T extends AbstractPerspective> {
 
-    public static final Persp<HomePerspective> HOME_PAGE = new Persp<HomePerspective>("Home", "Home Page", HomePerspective.class);
-    public static final Persp<TimelinePerspective> TIMELINE = new Persp<TimelinePerspective>("Home", "Timeline", TimelinePerspective.class);
-    public static final Persp<PeoplePerspective> PEOPLE = new Persp<PeoplePerspective>("Home", "People", PeoplePerspective.class);
-    public static final Persp<ProjectAuthoringPerspective> PROJECT_AUTHORING = new Persp<ProjectAuthoringPerspective>("Authoring", "Project Authoring", ProjectAuthoringPerspective.class);
-    public static final Persp<ContributorsPerspective> CONTRIBUTORS = new Persp<ContributorsPerspective>("Authoring", "Contributors", ContributorsPerspective.class);
-    public static final Persp<ArtifactRepositoryPerspective> ARTIFACT_REPOSITORY = new Persp<ArtifactRepositoryPerspective>("Authoring", "Artifact repository", ArtifactRepositoryPerspective.class);
-    public static final Persp<AdministrationPerspective> ADMINISTRATION = new Persp<AdministrationPerspective>("Authoring", "Administration", AdministrationPerspective.class);
-    public static final Persp<ProcessDeploymentsPerspective> PROCESS_DEPLOYMENTS = new Persp<ProcessDeploymentsPerspective>("Deploy", "Process Deployments", ProcessDeploymentsPerspective.class);
-    public static final Persp<RuleDeploymentsPerspective> RULE_DEPLOYMENTS = new Persp<RuleDeploymentsPerspective>("Deploy", "Rule Deployments", RuleDeploymentsPerspective.class);
-    public static final Persp<JobsPerspective> JOBS = new Persp<JobsPerspective>("Deploy", "Jobs", JobsPerspective.class);
-    public static final Persp<ProcessDefinitionsPerspective> PROCESS_DEFINITIONS = new Persp<ProcessDefinitionsPerspective>("Process Management", "Process Definitions", ProcessDefinitionsPerspective.class);
-    public static final Persp<ProcessInstancesPerspective> PROCESS_INSTANCES = new Persp<ProcessInstancesPerspective>("Process Management", "Process Instances", ProcessInstancesPerspective.class);
-    public static final Persp<TasksPerspective> TASKS = new Persp<TasksPerspective>("N/A", "N/A", TasksPerspective.class);
-    public static final Persp<ProcessAndTaskDashboardPerspective> PROCESS_AND_TASK_DASHBOARD = new Persp<ProcessAndTaskDashboardPerspective>("Dashboards", "Process & Task Dashboard", ProcessAndTaskDashboardPerspective.class);
-    public static final Persp<PluginManagementPerspective> PLUGIN_MANAGEMENT = new Persp<PluginManagementPerspective>("Extensions", "PlugIn Management", PluginManagementPerspective.class);
-    public static final Persp<AppsPerspective> APPS = new Persp<AppsPerspective>("Extensions", "Apps", AppsPerspective.class);
-    public static final Persp<DataSetsPerspective> DATA_SETS = new Persp<DataSetsPerspective>("Extensions", "Data Sets", DataSetsPerspective.class);
+    public static final Persp<HomePerspective> HOME_PAGE
+            = new Persp<HomePerspective>("Home", "Home Page", HomePerspective.class);
+
+    public static final Persp<TimelinePerspective> TIMELINE
+            = new Persp<TimelinePerspective>("Home", "Timeline", TimelinePerspective.class);
+
+    public static final Persp<PeoplePerspective> PEOPLE
+            = new Persp<PeoplePerspective>("Home", "People", PeoplePerspective.class);
+
+    public static final Persp<ProjectAuthoringPerspective> PROJECT_AUTHORING
+            = new Persp<ProjectAuthoringPerspective>("Authoring", "Project Authoring", ProjectAuthoringPerspective.class);
+
+    public static final Persp<ContributorsPerspective> CONTRIBUTORS
+            = new Persp<ContributorsPerspective>("Authoring", "Contributors", ContributorsPerspective.class);
+
+    public static final Persp<ArtifactRepositoryPerspective> ARTIFACT_REPOSITORY
+            = new Persp<ArtifactRepositoryPerspective>("Authoring", "Artifact repository", ArtifactRepositoryPerspective.class);
+
+    public static final Persp<AdministrationPerspective> ADMINISTRATION
+            = new Persp<AdministrationPerspective>("Authoring", "Administration", AdministrationPerspective.class);
+
+    public static final Persp<ProcessDeploymentsPerspective> PROCESS_DEPLOYMENTS
+            = new Persp<ProcessDeploymentsPerspective>("Deploy", "Process Deployments", ProcessDeploymentsPerspective.class, true);
+
+    public static final Persp<RuleDeploymentsPerspective> RULE_DEPLOYMENTS
+            = new Persp<RuleDeploymentsPerspective>("Deploy", "Rule Deployments", RuleDeploymentsPerspective.class);
+
+    public static final Persp<JobsPerspective> JOBS
+            = new Persp<JobsPerspective>("Deploy", "Jobs", JobsPerspective.class, true);
+
+    public static final Persp<ProcessDefinitionsPerspective> PROCESS_DEFINITIONS
+            = new Persp<ProcessDefinitionsPerspective>("Process Management", "Process Definitions", ProcessDefinitionsPerspective.class, true);
+
+    public static final Persp<ProcessInstancesPerspective> PROCESS_INSTANCES
+            = new Persp<ProcessInstancesPerspective>("Process Management", "Process Instances", ProcessInstancesPerspective.class, true);
+
+    public static final Persp<TasksPerspective> TASKS
+            = new Persp<TasksPerspective>("N/A", "Tasks", TasksPerspective.class);
+
+    public static final Persp<ProcessAndTaskDashboardPerspective> PROCESS_AND_TASK_DASHBOARD
+            = new Persp<ProcessAndTaskDashboardPerspective>("Dashboards", "Process & Task Dashboard", ProcessAndTaskDashboardPerspective.class, true);
+
+    public static final Persp<PluginManagementPerspective> PLUGIN_MANAGEMENT
+            = new Persp<PluginManagementPerspective>("Extensions", "PlugIn Management", PluginManagementPerspective.class);
+
+    public static final Persp<AppsPerspective> APPS
+            = new Persp<AppsPerspective>("Extensions", "Apps", AppsPerspective.class);
+
+    public static final Persp<DataSetsPerspective> DATA_SETS
+            = new Persp<DataSetsPerspective>("Extensions", "Data Sets", DataSetsPerspective.class);
 
     private static final List<Persp<? extends AbstractPerspective>> ALL_PERSPS = Collections.unmodifiableList(Arrays.asList(
             HOME_PAGE, TIMELINE, PEOPLE, PROJECT_AUTHORING, CONTRIBUTORS, ARTIFACT_REPOSITORY, ADMINISTRATION,
@@ -70,11 +103,27 @@ public class Persp<T extends AbstractPerspective> {
     private final String parentMenu;
     private final String menuItem;
     private final Class<T> perspPageObjectClass;
+    private final boolean isKieWbOnly; // = Perspective is present in kie-wb only, not in kie-drools-wb
 
     private Persp(String parentMenu, String menuItem, Class<T> perspPageObjectClass) {
+        this(parentMenu, menuItem, perspPageObjectClass, false);
+    }
+
+    /**
+     * @param parentMenu Name of the top level menu in which the menu item to
+     * access the perspective is present
+     * @param menuItem Name of the item in the menu to navigate to the
+     * perspective
+     * @param perspPageObjectClass Selenium Page Object class representing given
+     * perspective
+     * @param isKieWbOnly true if the perspective is present only in kie-wb (not
+     * in kie-drools-wb), false otherwise
+     */
+    private Persp(String parentMenu, String menuItem, Class<T> perspPageObjectClass, boolean isKieWbOnly) {
         this.parentMenu = parentMenu;
         this.menuItem = menuItem;
         this.perspPageObjectClass = perspPageObjectClass;
+        this.isKieWbOnly = isKieWbOnly;
     }
 
     public String getMenu() {
@@ -87,6 +136,10 @@ public class Persp<T extends AbstractPerspective> {
 
     public Class<T> getPerspectivePageObjectClass() {
         return perspPageObjectClass;
+    }
+
+    public boolean isKieWbOnly() {
+        return isKieWbOnly;
     }
 
     /**

--- a/kie-wb-smoke-tests/kie-wb-smoke-tests-main/src/test/java/org/kie/smoke/wb/selenium/ui/LoadAllPerspectivesIntegrationTest.java
+++ b/kie-wb-smoke-tests/kie-wb-smoke-tests-main/src/test/java/org/kie/smoke/wb/selenium/ui/LoadAllPerspectivesIntegrationTest.java
@@ -50,6 +50,9 @@ public class LoadAllPerspectivesIntegrationTest extends KieSeleniumTest {
     public static List<Object[]> perspectives() {
         List<Object[]> params = new ArrayList<Object[]>();
         for (Persp<?> p : Persp.getAllPerspectives()) {
+            if (!isKieWb && p.isKieWbOnly()) {
+                continue; //Don't add kie-wb specific perspectives when running aginst kie-drools-wb
+            }
             params.add(new Object[]{p});
         }
         return params;


### PR DESCRIPTION
Exclude some perspectives from LoadAllPerspectivesIntegrationTest (selenium smoke which tries to navigate to all perspectives and checks that they're loaded). The exclusion is done based on system property app.name which is set to kie-wb by default and overriden to kie-drools-wb when running smokes with kie-drools-wb maven profile.