### PR TITLE
Fix forgotten reference to Tomcat 8 war classifier

### DIFF
--- a/kie-wb-smoke-tests/kie-wb-smoke-tests-main/pom.xml
+++ b/kie-wb-smoke-tests/kie-wb-smoke-tests-main/pom.xml
@@ -687,7 +687,7 @@
                   <deployable>
                     <groupId>${deployable.groupId}</groupId>
                     <artifactId>${deployable.artifactId}</artifactId>
-                    <classifier>tomcat7</classifier> <!-- No Tomcat8 specific deployable needed (yet) -->
+                    <classifier>${tomcat8.deployable.classifier}</classifier>
                     <type>war</type>
                   </deployable>
                 </deployables>


### PR DESCRIPTION
This is related to https://github.com/droolsjbpm/kie-wb-distributions/pull/169. I forgot to fix one of the references to the classifier.