### PR TITLE
Fix smoke tests config for Tomcat 8

### DIFF
--- a/kie-wb-smoke-tests/pom.xml
+++ b/kie-wb-smoke-tests/pom.xml
@@ -20,6 +20,8 @@
     <version.wildfly8>8.2.1.Final</version.wildfly8>
 
     <tomcat7x.deployable.classifier>tomcat7</tomcat7x.deployable.classifier>
+    <!--  There is no Tomcat 8 specific WAR, so use the one for Tomcat 7-->
+    <tomcat8x.deployable.classifier>tomcat7</tomcat8x.deployable.classifier>
     <wildfly8x.deplyoble.classifier>wildfly8</wildfly8x.deplyoble.classifier>
     <eap64x.deployable.classifier>eap6_4</eap64x.deployable.classifier>
     <!-- The default setup (if not overidden by specific profile) will execute kie-wb smoke tests on EAP 6.4.x -->
@@ -536,13 +538,13 @@
         <dependency>
           <groupId>org.kie</groupId>
           <artifactId>kie-wb-distribution-wars</artifactId>
-          <classifier>tomcat7</classifier>
+          <classifier>${tomcat8x.deployable.classifier}</classifier>
           <type>war</type>
         </dependency>
         <dependency>
           <groupId>org.kie</groupId>
           <artifactId>kie-drools-wb-distribution-wars</artifactId>
-          <classifier>tomcat7</classifier>
+          <classifier>${tomcat8x.deployable.classifier}</classifier>
           <type>war</type>
         </dependency>
       </dependencies>
@@ -622,7 +624,7 @@
                   <deployable>
                     <groupId>${deployable.groupId}</groupId>
                     <artifactId>${deployable.artifactId}</artifactId>
-                    <classifier>tomcat7</classifier> <!-- No Tomcat8 specific deployable needed (yet) -->
+                    <classifier>${tomcat8x.deployable.classifier}</classifier>
                     <type>war</type>
                   </deployable>
                 </deployables>
@@ -790,6 +792,8 @@
 
       <properties>
         <tomcat7x.deployable.classifier>tomcat7-redhat</tomcat7x.deployable.classifier>
+        <!-- There is no Tomcat 8 specific WAR, so use the one for Tomcat 7 -->
+        <tomcat8x.deployable.classifier>tomcat7-redhat</tomcat8x.deployable.classifier>
         <!-- There is no WildFly 8 productized WAR -->
         <wildlfy8x.deployable.classifier>NONE</wildlfy8x.deployable.classifier>
         <eap64x.deployable.classifier>eap6_4-redhat</eap64x.deployable.classifier>


### PR DESCRIPTION
 * without the fix it was not possible to
   test prod (-redhat) WARs on Tomcat 8

Same fix was already merged to master. There is no approved BZ for this, but since these are just test fixes, I believe it is OK to be merged into 6.3.x.