### PR TITLE
JBPM-4906 RestWorkItemHandler fails with CNFE when using ResultSet

### DIFF
--- a/kie-wb/kie-wb-webapp/src/main/resources/META-INF/kie-wb-deployment-descriptor.xml
+++ b/kie-wb/kie-wb-webapp/src/main/resources/META-INF/kie-wb-deployment-descriptor.xml
@@ -30,7 +30,7 @@
     </work-item-handler>
     <work-item-handler>
       <resolver>mvel</resolver>
-      <identifier>new org.jbpm.process.workitem.rest.RESTWorkItemHandler()</identifier>
+      <identifier>new org.jbpm.process.workitem.rest.RESTWorkItemHandler(classLoader)</identifier>
       <parameters/>
       <name>Rest</name>
     </work-item-handler>


### PR DESCRIPTION
Configures the RESTWorkItemHandler with 'classLoader' argument by default, which allows to use ResultClass attribute in the WorkItem without any further changes.