### PR TITLE
Selenium smoke - create & save asset

### DIFF
--- a/kie-wb-smoke-tests/kie-wb-smoke-tests-main/src/main/java/org/kie/smoke/wb/selenium/model/CreateNewItemModal.java
+++ b/kie-wb-smoke-tests/kie-wb-smoke-tests-main/src/main/java/org/kie/smoke/wb/selenium/model/CreateNewItemModal.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2016 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.smoke.wb.selenium.model;
+
+import org.kie.smoke.wb.selenium.util.Waits;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+
+public class CreateNewItemModal extends ModalDialog {
+
+    public CreateNewItemModal(WebDriver driver) {
+        super(driver);
+    }
+
+    private void setFileName(String fileName) {
+        WebElement fileNameInput = Waits.elementPresent(driver, By.id("fileName"));
+        fileNameInput.sendKeys(fileName);
+    }
+
+    public void create(String fileName) {
+        setFileName(fileName);
+        //Wait for KieProjectService#resolvePackages
+        Waits.elementPresent(driver, By.xpath("//label[contains(.,'Package')]//following-sibling::div//span[contains(.,'<default>')]"));
+        ok();
+    }
+}

--- a/kie-wb-smoke-tests/kie-wb-smoke-tests-main/src/main/java/org/kie/smoke/wb/selenium/model/EnumerationEditor.java
+++ b/kie-wb-smoke-tests/kie-wb-smoke-tests-main/src/main/java/org/kie/smoke/wb/selenium/model/EnumerationEditor.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2016 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.smoke.wb.selenium.model;
+
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+import org.openqa.selenium.support.PageFactory;
+
+public class EnumerationEditor extends PageObject {
+
+    @FindBy(xpath = "//div[@class='uf-listbar-panel-header-toolbar']//button[contains(.,'Save')]")
+    private WebElement saveButton;
+
+    public EnumerationEditor(WebDriver driver) {
+        super(driver);
+    }
+
+    public void save(String commitMessage) {
+        saveButton.click();
+
+        //TODO wait for modal to appear
+        
+        SaveDialog saveModal = PageFactory.initElements(driver, SaveDialog.class);
+        saveModal.save(commitMessage);
+    }
+}

--- a/kie-wb-smoke-tests/kie-wb-smoke-tests-main/src/main/java/org/kie/smoke/wb/selenium/model/KieSeleniumTest.java
+++ b/kie-wb-smoke-tests/kie-wb-smoke-tests-main/src/main/java/org/kie/smoke/wb/selenium/model/KieSeleniumTest.java
@@ -20,6 +20,7 @@ import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.kie.smoke.wb.selenium.util.PageObjectFactory;
 import org.kie.smoke.wb.selenium.util.ScreenshotOnFailure;
+import org.openqa.selenium.Dimension;
 import org.openqa.selenium.WebDriver;
 
 public class KieSeleniumTest {
@@ -38,7 +39,8 @@ public class KieSeleniumTest {
     @BeforeClass
     public static void startWebDriver() {
         driver = WebDriverFactory.create();
-        driver.manage().window().maximize();
+        // window().maximize() still too slow on some jenkins slaves
+        driver.manage().window().setSize(new Dimension(1920, 1080));
 
         pof = new PageObjectFactory(driver);
     }

--- a/kie-wb-smoke-tests/kie-wb-smoke-tests-main/src/main/java/org/kie/smoke/wb/selenium/model/ModalDialog.java
+++ b/kie-wb-smoke-tests/kie-wb-smoke-tests-main/src/main/java/org/kie/smoke/wb/selenium/model/ModalDialog.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2016 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.smoke.wb.selenium.model;
+
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+
+public class ModalDialog extends PageObject {
+
+    @FindBy(xpath = "//button[contains(.,'Ok')]")
+    protected WebElement okButton;
+
+    public ModalDialog(WebDriver driver) {
+        super(driver);
+    }
+
+    protected void ok() {
+        okButton.click();
+    }
+}

--- a/kie-wb-smoke-tests/kie-wb-smoke-tests-main/src/main/java/org/kie/smoke/wb/selenium/model/Notification.java
+++ b/kie-wb-smoke-tests/kie-wb-smoke-tests-main/src/main/java/org/kie/smoke/wb/selenium/model/Notification.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2016 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.smoke.wb.selenium.model;
+
+import org.kie.smoke.wb.selenium.util.Waits;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+
+public class Notification extends PageObject {
+
+    @FindBy(css = "button[data-dismiss='alert']")
+    private WebElement closeButton;
+
+    public Notification(WebDriver driver) {
+        super(driver);
+    }
+
+    public String getMessage() {
+        WebElement popup = Waits.elementPresent(driver, By.cssSelector(".popupMiddle .alert"), 10);
+        String msg = popup.getText();
+        closeButton.click();
+        return msg;
+    }
+}

--- a/kie-wb-smoke-tests/kie-wb-smoke-tests-main/src/main/java/org/kie/smoke/wb/selenium/model/SaveDialog.java
+++ b/kie-wb-smoke-tests/kie-wb-smoke-tests-main/src/main/java/org/kie/smoke/wb/selenium/model/SaveDialog.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2016 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.smoke.wb.selenium.model;
+
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+
+public class SaveDialog extends ModalDialog {
+
+    @FindBy(xpath = "//div[@class='modal-dialog']//button[contains(.,'Save')]")
+    private WebElement saveButton;
+
+    @FindBy(css = "input[title='Check in comment']")
+    private WebElement checkInCommentInput;
+
+    public SaveDialog(WebDriver driver) {
+        super(driver);
+    }
+
+    public void save(String commitMsg) {
+        checkInCommentInput.sendKeys(commitMsg);
+        save();
+    }
+
+    private void save() {
+        saveButton.click();
+    }
+}

--- a/kie-wb-smoke-tests/kie-wb-smoke-tests-main/src/main/java/org/kie/smoke/wb/selenium/model/SecondaryNavbar.java
+++ b/kie-wb-smoke-tests/kie-wb-smoke-tests-main/src/main/java/org/kie/smoke/wb/selenium/model/SecondaryNavbar.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2016 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.smoke.wb.selenium.model;
+
+import org.kie.smoke.wb.selenium.util.ByUtil;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.PageFactory;
+
+public class SecondaryNavbar extends PageObject {
+
+    /* Works both for menu titles (e.g. New Item) and menu items (e.g. Drl File) */
+    private static final String MENU_LINK = "//ul[contains(@class,'navbar-persistent')]//a[contains(text(),'%s')]";
+
+    public SecondaryNavbar(WebDriver driver) {
+        super(driver);
+    }
+
+    public CreateNewItemModal newItem(Item i) {
+        menuLink("New Item").click();
+        menuLink(i.toString()).click();
+        return PageFactory.initElements(driver, CreateNewItemModal.class);
+    }
+
+    public static enum Item {
+
+        Data_Object,
+        DRL_file,
+        Enumeration;
+
+        @Override
+        public String toString() {
+            return name().replace('_', ' ');
+        }
+    }
+
+    private WebElement menuLink(String title) {
+        return driver.findElement(ByUtil.xpath(MENU_LINK, title));
+    }
+}

--- a/kie-wb-smoke-tests/kie-wb-smoke-tests-main/src/main/java/org/kie/smoke/wb/selenium/model/persps/ProcessAndTaskDashboardPerspective.java
+++ b/kie-wb-smoke-tests/kie-wb-smoke-tests-main/src/main/java/org/kie/smoke/wb/selenium/model/persps/ProcessAndTaskDashboardPerspective.java
@@ -15,13 +15,16 @@
  */
 package org.kie.smoke.wb.selenium.model.persps;
 
+import com.google.common.base.Predicate;
 import org.kie.smoke.wb.selenium.util.Waits;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.support.ui.WebDriverWait;
 
 public class ProcessAndTaskDashboardPerspective extends AbstractPerspective {
 
     private static final By PROCESSES_TAB = By.id("processes");
+    private static final By LOADING_INDICATOR = By.xpath("//div[@class='gwt-Label'][contains(.,'Loading dashboard')]");
 
     public ProcessAndTaskDashboardPerspective(WebDriver driver) {
         super(driver);
@@ -30,5 +33,17 @@ public class ProcessAndTaskDashboardPerspective extends AbstractPerspective {
     @Override
     public boolean isDisplayed() {
         return Waits.isElementPresent(driver, PROCESSES_TAB);
+    }
+
+    @Override
+    public void waitForLoaded() {
+        new WebDriverWait(driver, 10).until(
+                new Predicate<WebDriver>() {
+                    @Override
+                    public boolean apply(WebDriver t) {
+                        return driver.findElements(LOADING_INDICATOR).isEmpty();
+                    }
+                }
+        );
     }
 }

--- a/kie-wb-smoke-tests/kie-wb-smoke-tests-main/src/main/java/org/kie/smoke/wb/selenium/model/persps/ProjectAuthoringPerspective.java
+++ b/kie-wb-smoke-tests/kie-wb-smoke-tests-main/src/main/java/org/kie/smoke/wb/selenium/model/persps/ProjectAuthoringPerspective.java
@@ -15,9 +15,13 @@
  */
 package org.kie.smoke.wb.selenium.model.persps;
 
+import org.kie.smoke.wb.selenium.model.CreateNewItemModal;
+import org.kie.smoke.wb.selenium.model.EnumerationEditor;
+import org.kie.smoke.wb.selenium.model.SecondaryNavbar;
 import org.kie.smoke.wb.selenium.util.Waits;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.support.PageFactory;
 
 public class ProjectAuthoringPerspective extends AbstractPerspective {
 
@@ -25,8 +29,11 @@ public class ProjectAuthoringPerspective extends AbstractPerspective {
     //Project explorer bradcrumb toggle, whose presence indicates that PEX content has been loaded
     private static final By PEX_BREADCRUMB_TOGGLE = By.cssSelector(".fa-chevron-down");
 
+    private final SecondaryNavbar secondaryNavbar;
+
     public ProjectAuthoringPerspective(WebDriver driver) {
         super(driver);
+        secondaryNavbar = PageFactory.initElements(driver, SecondaryNavbar.class);
     }
 
     @Override
@@ -37,5 +44,20 @@ public class ProjectAuthoringPerspective extends AbstractPerspective {
     @Override
     public boolean isDisplayed() {
         return Waits.isElementPresent(driver, PROJECT_EXPLORER_TITLE);
+    }
+
+    public SecondaryNavbar getSecondaryNavbar() {
+        return secondaryNavbar;
+    }
+
+    public EnumerationEditor newEnumeration(String filename) {
+        CreateNewItemModal modal = secondaryNavbar.newItem(SecondaryNavbar.Item.Enumeration);
+        modal.create(filename);
+        return PageFactory.initElements(driver, EnumerationEditor.class);
+    }
+
+    public ProjectEditor openProjectEditor() {
+        driver.findElement(By.xpath("//button[contains(.,'Open Project Editor')]")).click();
+        return PageFactory.initElements(driver, ProjectEditor.class);
     }
 }

--- a/kie-wb-smoke-tests/kie-wb-smoke-tests-main/src/main/java/org/kie/smoke/wb/selenium/model/persps/ProjectEditor.java
+++ b/kie-wb-smoke-tests/kie-wb-smoke-tests-main/src/main/java/org/kie/smoke/wb/selenium/model/persps/ProjectEditor.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2016 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.smoke.wb.selenium.model.persps;
+
+import org.kie.smoke.wb.selenium.model.PageObject;
+import org.kie.smoke.wb.selenium.util.Waits;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+
+public class ProjectEditor extends PageObject {
+
+    private static final By PROJ_EDITOR_TITLE = By.cssSelector(".uf-listbar-panel-header-title-text[title^=Project]");
+
+    public ProjectEditor(WebDriver driver) {
+        super(driver);
+        //Wait for Project Editor to be opened
+        Waits.elementPresent(driver, PROJ_EDITOR_TITLE, 5);
+    }
+
+    public void buildAndDeploy() {
+        driver.findElement(By.xpath("//button[contains(.,'Build')]")).click();
+        Waits.elementVisible(driver, By.linkText("Build & Deploy"), 1).click();
+    }
+}

--- a/kie-wb-smoke-tests/kie-wb-smoke-tests-main/src/main/java/org/kie/smoke/wb/selenium/util/PageObjectFactory.java
+++ b/kie-wb-smoke-tests/kie-wb-smoke-tests-main/src/main/java/org/kie/smoke/wb/selenium/util/PageObjectFactory.java
@@ -17,6 +17,8 @@ package org.kie.smoke.wb.selenium.util;
 
 import org.kie.smoke.wb.selenium.model.PrimaryNavbar;
 import org.kie.smoke.wb.selenium.model.LoginPage;
+import org.kie.smoke.wb.selenium.model.Notification;
+import org.kie.smoke.wb.selenium.model.SecondaryNavbar;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.support.PageFactory;
 
@@ -36,8 +38,16 @@ public class PageObjectFactory {
         return createPageObject(LoginPage.class);
     }
 
-    public PrimaryNavbar createNavBar() {
+    public PrimaryNavbar createPrimaryNavbar() {
         return createPageObject(PrimaryNavbar.class);
+    }
+
+    public SecondaryNavbar createSecondaryNavbar() {
+        return createPageObject(SecondaryNavbar.class);
+    }
+
+    public Notification createNotification() {
+        return createPageObject(Notification.class);
     }
 
     private <T> T createPageObject(Class<T> pageObjectClass) {

--- a/kie-wb-smoke-tests/kie-wb-smoke-tests-main/src/main/java/org/kie/smoke/wb/selenium/util/Waits.java
+++ b/kie-wb-smoke-tests/kie-wb-smoke-tests-main/src/main/java/org/kie/smoke/wb/selenium/util/Waits.java
@@ -26,8 +26,8 @@ public class Waits {
 
     private static final int DEFAULT_TIMEOUT = 15;
 
-    public static void elementVisible(WebDriver driver, By locator, int timeoutSeconds) {
-        new WebDriverWait(driver, timeoutSeconds)
+    public static WebElement elementVisible(WebDriver driver, By locator, int timeoutSeconds) {
+        return new WebDriverWait(driver, timeoutSeconds)
                 .until(ExpectedConditions.visibilityOfElementLocated(locator));
     }
 

--- a/kie-wb-smoke-tests/kie-wb-smoke-tests-main/src/test/java/org/kie/smoke/wb/selenium/ui/CreateAndSaveAssetIntegrationTest.java
+++ b/kie-wb-smoke-tests/kie-wb-smoke-tests-main/src/test/java/org/kie/smoke/wb/selenium/ui/CreateAndSaveAssetIntegrationTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2016 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.smoke.wb.selenium.ui;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.kie.smoke.wb.category.KieWbSeleniumSmoke;
+import org.kie.smoke.wb.selenium.model.EnumerationEditor;
+import org.kie.smoke.wb.selenium.model.KieSeleniumTest;
+import static org.kie.smoke.wb.selenium.model.KieSeleniumTest.KIE_PASS;
+import static org.kie.smoke.wb.selenium.model.KieSeleniumTest.KIE_USER;
+import org.kie.smoke.wb.selenium.model.LoginPage;
+import org.kie.smoke.wb.selenium.model.PrimaryNavbar;
+import org.kie.smoke.wb.selenium.model.persps.ProjectAuthoringPerspective;
+import org.kie.smoke.wb.selenium.model.persps.ProjectEditor;
+
+@Category(KieWbSeleniumSmoke.class)
+public class CreateAndSaveAssetIntegrationTest extends KieSeleniumTest {
+
+    @Test
+    public void createAndSaveEnum() throws InterruptedException {
+        ProjectAuthoringPerspective pa = goToAuthoring();
+
+        EnumerationEditor enumEditor = pa.newEnumeration("MyFirstEnum");
+        expectNotification("Item successfully created");
+
+        enumEditor.save("I created my first enumeration");
+        expectNotification("Item successfully saved");
+
+        ProjectEditor projEditor = pa.openProjectEditor();
+        projEditor.buildAndDeploy();
+        expectNotification("Build Successful");
+    }
+
+    private void expectNotification(String expectedMessage) {
+        String notificationMsg = pof.createNotification().getMessage();
+        Assert.assertTrue("Notification '" + expectedMessage + "' should be displayed",
+                notificationMsg.contains(expectedMessage));
+    }
+
+    private ProjectAuthoringPerspective goToAuthoring() {
+        LoginPage lp = pof.createLoginPage();
+        PrimaryNavbar navbar = lp.loginAs(KIE_USER, KIE_PASS).getNavbar();
+        return navbar.projectAuthoring();
+    }
+}


### PR DESCRIPTION
## Work in progress - don't merge yet

Selenium tests that navigates to authoring, creates and saves new enumeration and builds & deploys the current project. Success is only verified by checking that Success notifications appeared.

Added some explicit waits to prevent occasional fails in LoadAllPerspectivesIntegrationTest

TODO: Some stabilization + testing on IE needed
TODO: it seems that the tests are influenced by some REST API smoke tests, which create some org units and as a result change which org unit is selected by default in the UI. This will have to be dealt with either by isolating the selenium tests or by selecting the correct (Evaluation) org unit / repo / project in project explorer.