### PR TITLE
Stabilize selenium smokes

### DIFF
--- a/kie-wb-smoke-tests/kie-wb-smoke-tests-main/src/main/java/org/kie/smoke/wb/selenium/model/persps/PeoplePerspective.java
+++ b/kie-wb-smoke-tests/kie-wb-smoke-tests-main/src/main/java/org/kie/smoke/wb/selenium/model/persps/PeoplePerspective.java
@@ -21,7 +21,7 @@ import org.openqa.selenium.WebDriver;
 
 public class PeoplePerspective extends AbstractPerspective {
 
-    private static final By PROFILE_HOME_BUTTON = By.cssSelector("button[title=\"Go To User's Home\"]");
+    private static final By PROFILE_HOME_BUTTON = By.cssSelector("button[title^='Go To User']");
 
     public PeoplePerspective(WebDriver driver) {
         super(driver);

--- a/kie-wb-smoke-tests/kie-wb-smoke-tests-main/src/main/java/org/kie/smoke/wb/selenium/model/persps/ProcessAndTaskDashboardPerspective.java
+++ b/kie-wb-smoke-tests/kie-wb-smoke-tests-main/src/main/java/org/kie/smoke/wb/selenium/model/persps/ProcessAndTaskDashboardPerspective.java
@@ -15,9 +15,11 @@
  */
 package org.kie.smoke.wb.selenium.model.persps;
 
+import org.kie.smoke.wb.selenium.util.LoadingIndicator;
 import org.kie.smoke.wb.selenium.util.Waits;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.support.PageFactory;
 
 public class ProcessAndTaskDashboardPerspective extends AbstractPerspective {
 
@@ -30,5 +32,11 @@ public class ProcessAndTaskDashboardPerspective extends AbstractPerspective {
     @Override
     public boolean isDisplayed() {
         return Waits.isElementPresent(driver, PROCESSES_TAB);
+    }
+
+    @Override
+    public void waitForLoaded() {
+        LoadingIndicator indicator = PageFactory.initElements(driver, LoadingIndicator.class);
+        indicator.disappear("Loading dashboard");
     }
 }

--- a/kie-wb-smoke-tests/kie-wb-smoke-tests-main/src/main/java/org/kie/smoke/wb/selenium/model/persps/TasksPerspective.java
+++ b/kie-wb-smoke-tests/kie-wb-smoke-tests-main/src/main/java/org/kie/smoke/wb/selenium/model/persps/TasksPerspective.java
@@ -15,9 +15,11 @@
  */
 package org.kie.smoke.wb.selenium.model.persps;
 
+import org.kie.smoke.wb.selenium.util.LoadingIndicator;
 import org.kie.smoke.wb.selenium.util.Waits;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.support.PageFactory;
 
 public class TasksPerspective extends AbstractPerspective {
 
@@ -30,5 +32,11 @@ public class TasksPerspective extends AbstractPerspective {
     @Override
     public boolean isDisplayed() {
         return Waits.isElementPresent(driver, ACTIVE_FILTER_TITLE);
+    }
+
+    @Override
+    public void waitForLoaded() {
+        LoadingIndicator indicator = PageFactory.initElements(driver, LoadingIndicator.class);
+        indicator.disappear("Loading");
     }
 }

--- a/kie-wb-smoke-tests/kie-wb-smoke-tests-main/src/main/java/org/kie/smoke/wb/selenium/util/LoadingIndicator.java
+++ b/kie-wb-smoke-tests/kie-wb-smoke-tests-main/src/main/java/org/kie/smoke/wb/selenium/util/LoadingIndicator.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2016 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.smoke.wb.selenium.util;
+
+import com.google.common.base.Predicate;
+import org.kie.smoke.wb.selenium.model.PageObject;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.support.ui.WebDriverWait;
+
+public class LoadingIndicator extends PageObject {
+
+    public LoadingIndicator(WebDriver driver) {
+        super(driver);
+    }
+
+    public void disappear(String msg) {
+        final By loadingIndicator = By.xpath("//div[@class='gwt-Label'][contains(.,'" + msg + "')]");
+        new WebDriverWait(driver, 10).until(new Predicate<WebDriver>() {
+            @Override
+            public boolean apply(WebDriver driver) {
+                return driver.findElements(loadingIndicator).isEmpty();
+            }
+        });
+    }
+}


### PR DESCRIPTION
Addressing recent flakiness of kie-wb selenium smoke jobs.
1) Problems with navigating to PlugIn Management / Process & Task Dashboard perspectives because the previous perspectives were not fully loaded -> Added explicit wait for those persps. to be loaded.
2) Change in locator after recent i18n commits