### PR TITLE
Do not include empty dirs inside WEB-INF/classes

### DIFF
--- a/kie-drools-wb/kie-drools-wb-webapp/pom.xml
+++ b/kie-drools-wb/kie-drools-wb-webapp/pom.xml
@@ -1560,7 +1560,11 @@
         <configuration>
           <packagingExcludes>
             WEB-INF/classes/javax/**/*.*,
-            WEB-INF/classes/**/client/**/*.class,
+            WEB-INF/classes/org/kie/workbench/drools/client/**/*.class,
+            WEB-INF/classes/org/kie/workbench/drools/client/resources/i18n/App*.properties,
+            WEB-INF/classes/org/kie/workbench/drools/client/docks/**,
+            WEB-INF/classes/org/kie/workbench/drools/client/navbar/**,
+            WEB-INF/classes/org/kie/workbench/drools/client/perspectives/**,
             WEB-INF/classes/**/public/**,
             WEB-INF/classes/logback.xml,
             **/*.gwt.xml,

--- a/kie-wb/kie-wb-webapp/pom.xml
+++ b/kie-wb/kie-wb-webapp/pom.xml
@@ -1806,7 +1806,12 @@
         <configuration>
           <packagingExcludes>
             WEB-INF/classes/javax/**/*.*,
-            WEB-INF/classes/**/client/**/*.class,
+            WEB-INF/classes/org/kie/workbench/client/**/*.class,
+            WEB-INF/classes/org/kie/workbench/client/resources/i18n/App*.properties,
+            WEB-INF/classes/org/kie/workbench/client/docks/**,
+            WEB-INF/classes/org/kie/workbench/client/navbar/**,
+            WEB-INF/classes/org/kie/workbench/client/perspectives/**,
+
             WEB-INF/classes/**/public/**,
             WEB-INF/classes/logback.xml,
             **/*.gwt.xml,


### PR DESCRIPTION
The previous pattern was leaving empty directories which is both ugly and also complicates testing of the patches a bit. I had to list all the dirs specifically as I could find other way (note that we need to keep ...workbench/drools/client/i18n dir in place as it contains required properties files)