### PR TITLE
Fix for positioning utility menu bar

### DIFF
--- a/kie-drools-wb/kie-drools-wb-distribution-wars/src/main/productized/styles/product.css
+++ b/kie-drools-wb/kie-drools-wb-distribution-wars/src/main/productized/styles/product.css
@@ -51,3 +51,13 @@
     border-top-color: #949699;
     border-bottom-color: #6B6F74;
 }
+
+.navbar-pf ul.navbar-utility > li > a {
+    margin-top: 6px;
+    padding-bottom: 5px;
+    padding-top: 4px;
+}
+
+.navbar-pf ul.navbar-utility li.dropdown > .dropdown-toggle .pficon-user {
+    top: 5px;
+}

--- a/kie-wb/kie-wb-distribution-wars/src/main/productized/styles/product.css
+++ b/kie-wb/kie-wb-distribution-wars/src/main/productized/styles/product.css
@@ -51,3 +51,13 @@
     border-top-color: #949699;
     border-bottom-color: #6B6F74;
 }
+
+.navbar-pf ul.navbar-utility > li > a {
+    margin-top: 6px;
+    padding-bottom: 5px;
+    padding-top: 4px;
+}
+
+.navbar-pf ul.navbar-utility li.dropdown > .dropdown-toggle .pficon-user {
+    top: 5px;
+}


### PR DESCRIPTION
Moved menu a few pixels down to not overlap with top red bar.

From this: 

![selection_057](https://cloud.githubusercontent.com/assets/570894/13119425/d44dd18c-d5f4-11e5-860b-b9289bfebc71.png)

To:

![selection_058](https://cloud.githubusercontent.com/assets/570894/13119499/2adbc342-d5f5-11e5-8bdb-79e9cdee2463.png)
