### PR TITLE
[6.4.x] BZ1315760: kie-config-cli: 'Auth failure' trying to work with repositories

### DIFF
--- a/kie-config-cli/src/main/java/org/kie/config/cli/command/impl/CloneGitRepositoryCliCommand.java
+++ b/kie-config-cli/src/main/java/org/kie/config/cli/command/impl/CloneGitRepositoryCliCommand.java
@@ -20,7 +20,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.eclipse.jgit.transport.CredentialsProvider;
-import org.guvnor.structure.server.repositories.RepositoryFactoryHelper;
+import org.eclipse.jgit.transport.SshSessionFactory;
 import org.jboss.weld.environment.se.WeldContainer;
 import org.jboss.weld.literal.NamedLiteral;
 import org.kie.config.cli.CliContext;
@@ -75,6 +75,11 @@ public class CloneGitRepositoryCliCommand implements CliCommand {
         env.put( "origin", systemGitRepoUrl );
 
         if ( gitUri.getScheme().equalsIgnoreCase( "ssh" ) ) {
+            // JGitFileSystemProvider's initialization configures the SshSessionFactory to use a per-session CredentialsProvider
+            // expecting public-private keys for the SSH protocol. Revert the SshSessionFactory configuration to use the default
+            // Factory that uses the default CredentialsProvider configured below.
+            SshSessionFactory.setInstance( null );
+
             // use special credential provider to support prompt for SSH connections to unknown hosts
             CredentialsProvider.setDefault( new InteractiveUsernamePasswordCredentialsProvider( user, password, context.getInput() ) );
         } else {


### PR DESCRIPTION
See https://bugzilla.redhat.com/show_bug.cgi?id=1315760

@csadilek Yes, no tests.. ```kie-cli-config``` is a real can of worms. One day it'll be re-written to use a ```REST``` API (rather than clone ```system.git``` locally...)

This is the corollary of https://github.com/droolsjbpm/kie-wb-distributions/pull/222 for 6.4.x

(cherry picked from commit 44ba33dc430e067a4f02e9d7befa91646b9eb43b)