### PR TITLE
BZ1315757: [GSS](6.2.z) kie-config-cli: 'Auth failure' trying to work with repositories

### DIFF
--- a/kie-config-cli/src/main/java/org/kie/config/cli/command/impl/CloneGitRepositoryCliCommand.java
+++ b/kie-config-cli/src/main/java/org/kie/config/cli/command/impl/CloneGitRepositoryCliCommand.java
@@ -20,7 +20,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.eclipse.jgit.transport.CredentialsProvider;
-import org.guvnor.structure.server.repositories.RepositoryFactoryHelper;
+import org.eclipse.jgit.transport.SshSessionFactory;
 import org.jboss.weld.environment.se.WeldContainer;
 import org.jboss.weld.literal.NamedLiteral;
 import org.kie.config.cli.CliContext;
@@ -75,6 +75,11 @@ public class CloneGitRepositoryCliCommand implements CliCommand {
         env.put( "origin", systemGitRepoUrl );
 
         if ( gitUri.getScheme().equalsIgnoreCase( "ssh" ) ) {
+            // JGitFileSystemProvider's initialization configures the SshSessionFactory to use a per-session CredentialsProvider
+            // expecting public-private keys for the SSH protocol. Revert the SshSessionFactory configuration to use the default
+            // Factory that uses the default CredentialsProvider configured below.
+            SshSessionFactory.setInstance( null );
+
             // use special credential provider to support prompt for SSH connections to unknown hosts
             CredentialsProvider.setDefault( new InteractiveUsernamePasswordCredentialsProvider( user, password, context.getInput() ) );
         } else {


### PR DESCRIPTION
See https://bugzilla.redhat.com/show_bug.cgi?id=1315757

This is the corollary of https://github.com/droolsjbpm/kie-wb-distributions/pull/222 for 6.3.x

(cherry picked from commit 44ba33dc430e067a4f02e9d7befa91646b9eb43b)