### PR TITLE
BZ-1319053: Messages window can't be reopened after closing

### DIFF
--- a/kie-drools-wb/kie-drools-wb-webapp/src/main/java/org/kie/workbench/drools/client/perspectives/DroolsAuthoringPerspective.java
+++ b/kie-drools-wb/kie-drools-wb-webapp/src/main/java/org/kie/workbench/drools/client/perspectives/DroolsAuthoringPerspective.java
@@ -147,6 +147,13 @@ public class DroolsAuthoringPerspective {
                     }
                 } )
                 .endMenu()
+                .newTopLevelMenu( constants.Messages() ).position( MenuPosition.RIGHT ).respondsWith( new Command() {
+                    @Override
+                    public void execute() {
+                        placeManager.goTo( "org.kie.workbench.common.screens.messageconsole.MessageConsole" );
+                    }
+                } )
+                .endMenu()
                 .build();
     }
 
@@ -194,6 +201,13 @@ public class DroolsAuthoringPerspective {
                     @Override
                     public void execute() {
                         placeManager.goTo( "FindForm" );
+                    }
+                } )
+                .endMenu()
+                .newTopLevelMenu( constants.Messages() ).position( MenuPosition.RIGHT ).respondsWith( new Command() {
+                    @Override
+                    public void execute() {
+                        placeManager.goTo( "org.kie.workbench.common.screens.messageconsole.MessageConsole" );
                     }
                 } )
                 .endMenu()

--- a/kie-drools-wb/kie-drools-wb-webapp/src/main/java/org/kie/workbench/drools/client/resources/i18n/AppConstants.java
+++ b/kie-drools-wb/kie-drools-wb-webapp/src/main/java/org/kie/workbench/drools/client/resources/i18n/AppConstants.java
@@ -122,4 +122,6 @@ public interface AppConstants
 
     String Examples();
 
+    String Messages();
+
 }

--- a/kie-drools-wb/kie-drools-wb-webapp/src/main/resources/org/kie/workbench/drools/client/resources/i18n/AppConstants.properties
+++ b/kie-drools-wb/kie-drools-wb-webapp/src/main/resources/org/kie/workbench/drools/client/resources/i18n/AppConstants.properties
@@ -42,3 +42,4 @@ DataSets=Data Sets
 logoBannerError=Failed to load banner.
 assetSearch=Asset Search
 Examples=Example
+Messages=Messages

--- a/kie-wb/kie-wb-webapp/src/main/java/org/kie/workbench/client/perspectives/DroolsAuthoringPerspective.java
+++ b/kie-wb/kie-wb-webapp/src/main/java/org/kie/workbench/client/perspectives/DroolsAuthoringPerspective.java
@@ -148,6 +148,13 @@ public class DroolsAuthoringPerspective {
                     }
                 } )
                 .endMenu()
+                .newTopLevelMenu( constants.Messages() ).position( MenuPosition.RIGHT ).respondsWith( new Command() {
+                    @Override
+                    public void execute() {
+                        placeManager.goTo( "org.kie.workbench.common.screens.messageconsole.MessageConsole" );
+                    }
+                } )
+                .endMenu()
                 .build();
     }
 
@@ -195,6 +202,13 @@ public class DroolsAuthoringPerspective {
                     @Override
                     public void execute() {
                         placeManager.goTo( "FindForm" );
+                    }
+                } )
+                .endMenu()
+                .newTopLevelMenu( constants.Messages() ).position( MenuPosition.RIGHT ).respondsWith( new Command() {
+                    @Override
+                    public void execute() {
+                        placeManager.goTo( "org.kie.workbench.common.screens.messageconsole.MessageConsole" );
                     }
                 } )
                 .endMenu()

--- a/kie-wb/kie-wb-webapp/src/main/java/org/kie/workbench/client/resources/i18n/AppConstants.java
+++ b/kie-wb/kie-wb-webapp/src/main/java/org/kie/workbench/client/resources/i18n/AppConstants.java
@@ -138,4 +138,6 @@ public interface AppConstants
 
     String Examples();
 
+    String Messages();
+
 }

--- a/kie-wb/kie-wb-webapp/src/main/resources/org/kie/workbench/client/resources/i18n/AppConstants.properties
+++ b/kie-wb/kie-wb-webapp/src/main/resources/org/kie/workbench/client/resources/i18n/AppConstants.properties
@@ -50,3 +50,4 @@ DataSets=Data Sets
 logoBannerError=Failed to load banner.
 assetSearch=Asset Search
 Examples=Example
+Messages=Messages


### PR DESCRIPTION
A menu item to open the Messages window was added: 

![menu](https://cloud.githubusercontent.com/assets/832830/13932535/2ea62c46-ef87-11e5-8b3b-b954a0fda14b.png)
