### PR TITLE
[6.4.x] BZ1320813: [ru_RU][zh_TW] Add Russian and Traditional Chinese to language list in workbench settings

### DIFF
--- a/kie-drools-wb/kie-drools-wb-webapp/src/main/resources/org/kie/workbench/drools/KIEDroolsWebapp.gwt.xml
+++ b/kie-drools-wb/kie-drools-wb-webapp/src/main/resources/org/kie/workbench/drools/KIEDroolsWebapp.gwt.xml
@@ -112,6 +112,8 @@
   <extend-property name="locale" values="pt_BR"/>
   <extend-property name="locale" values="zh_CN"/>
   <extend-property name="locale" values="de"/>
+  <extend-property name="locale" values="zh_TW"/>
+  <extend-property name="locale" values="ru"/>
 
   <!-- We don't need to support IE10 or older -->
   <!-- There is no "ie11" permutation. IE11 uses the Firefox one (gecko1_8) -->

--- a/kie-wb/kie-wb-webapp/src/main/resources/org/kie/workbench/KIEWebapp.gwt.xml
+++ b/kie-wb/kie-wb-webapp/src/main/resources/org/kie/workbench/KIEWebapp.gwt.xml
@@ -120,6 +120,8 @@
   <extend-property name="locale" values="pt_BR"/>
   <extend-property name="locale" values="zh_CN"/>
   <extend-property name="locale" values="de"/>
+  <extend-property name="locale" values="zh_TW"/>
+  <extend-property name="locale" values="ru"/>
 
   <!-- We don't need to support IE10 or older -->
   <!-- There is no "ie11" permutation. IE11 uses the Firefox one (gecko1_8) -->


### PR DESCRIPTION
See https://bugzilla.redhat.com/show_bug.cgi?id=1320813

This commit enables GWT's compilation of locales "ru" and "zh_TW".