### PR TITLE
Remove resteasy-cdi from -webapps - not needed

### DIFF
--- a/kie-drools-wb/kie-drools-wb-webapp/pom.xml
+++ b/kie-drools-wb/kie-drools-wb-webapp/pom.xml
@@ -134,12 +134,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.jboss.resteasy</groupId>
-      <artifactId>resteasy-cdi</artifactId>
-      <scope>provided</scope>
-    </dependency>
-
-    <dependency>
       <groupId>xalan</groupId>
       <artifactId>xalan</artifactId>
       <scope>provided</scope>

--- a/kie-wb/kie-wb-webapp/pom.xml
+++ b/kie-wb/kie-wb-webapp/pom.xml
@@ -134,18 +134,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.jboss.resteasy</groupId>
-      <artifactId>resteasy-cdi</artifactId>
-      <scope>provided</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>javassist</groupId>
-          <artifactId>javassist</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-
-    <dependency>
       <groupId>dom4j</groupId>
       <artifactId>dom4j</artifactId>
       <scope>provided</scope>


### PR DESCRIPTION
 * the -webapps are deployed on top of WFLY,
   which already contains the resteasy libs.
 * resteasy is only bundled into Tomcat WARs,
   but that is done in the -distribution-wars
   modules