### PR TITLE
Prevent occasional fails in selenium smokes on Windows

### DIFF
--- a/kie-wb-smoke-tests/kie-wb-smoke-tests-main/src/main/java/org/kie/smoke/wb/selenium/model/persps/TasksPerspective.java
+++ b/kie-wb-smoke-tests/kie-wb-smoke-tests-main/src/main/java/org/kie/smoke/wb/selenium/model/persps/TasksPerspective.java
@@ -38,5 +38,7 @@ public class TasksPerspective extends AbstractPerspective {
     public void waitForLoaded() {
         LoadingIndicator indicator = PageFactory.initElements(driver, LoadingIndicator.class);
         indicator.disappear("Loading");
+        // additional wait, because navigation to next persp occasionally fails on windows
+        Waits.pause(2000);
     }
 }


### PR DESCRIPTION
Analyzing the occasional fails in [kie-wb-smoke](https://kie-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/kie-wb-smoke-selenium-windows-6.4.x/) on windows it is most likely that navigation to Plugin management perspective fails because Task list perspective was not yet fully loaded (as seen in screenshot artifacts in any of the yellow-ball job runs).

Current implementation was already waiting for perspective loading animation to disappear. Since disappearance of that is the last observable thing that happens in the DOM during the perspective loading, there is nothing better to use for waiting for perspective to load -> I added additional 2s wait for tasklist perspective to load.