### PR TITLE
[6.3.x] BZ-1320502: AdministrationPerspective not loading for administrative user whose roles is not defined as admin

### DIFF
--- a/kie-drools-wb/kie-drools-wb-webapp/src/main/java/org/kie/workbench/drools/client/perspectives/AdministrationPerspective.java
+++ b/kie-drools-wb/kie-drools-wb-webapp/src/main/java/org/kie/workbench/drools/client/perspectives/AdministrationPerspective.java
@@ -34,7 +34,6 @@ import org.uberfire.client.workbench.panels.impl.MultiListWorkbenchPanelPresente
 import org.uberfire.client.workbench.panels.impl.SimpleWorkbenchPanelPresenter;
 import org.uberfire.mvp.Command;
 import org.uberfire.mvp.impl.DefaultPlaceRequest;
-import org.uberfire.security.annotations.Roles;
 import org.uberfire.workbench.model.CompassPosition;
 import org.uberfire.workbench.model.PanelDefinition;
 import org.uberfire.workbench.model.PerspectiveDefinition;
@@ -49,7 +48,6 @@ import static org.kie.workbench.drools.client.security.KieWorkbenchFeatures.*;
 /**
  * A Perspective for Administrators
  */
-@Roles({ "admin" })
 @ApplicationScoped
 @WorkbenchPerspective(identifier = "AdministrationPerspective")
 public class AdministrationPerspective {

--- a/kie-wb/kie-wb-webapp/src/main/java/org/kie/workbench/client/perspectives/AdministrationPerspective.java
+++ b/kie-wb/kie-wb-webapp/src/main/java/org/kie/workbench/client/perspectives/AdministrationPerspective.java
@@ -34,7 +34,6 @@ import org.uberfire.client.workbench.panels.impl.MultiListWorkbenchPanelPresente
 import org.uberfire.client.workbench.panels.impl.SimpleWorkbenchPanelPresenter;
 import org.uberfire.mvp.Command;
 import org.uberfire.mvp.impl.DefaultPlaceRequest;
-import org.uberfire.security.annotations.Roles;
 import org.uberfire.workbench.model.CompassPosition;
 import org.uberfire.workbench.model.PanelDefinition;
 import org.uberfire.workbench.model.PerspectiveDefinition;
@@ -49,7 +48,6 @@ import static org.kie.workbench.client.security.KieWorkbenchFeatures.*;
 /**
  * A Perspective for Administrators
  */
-@Roles({ "admin" })
 @ApplicationScoped
 @WorkbenchPerspective(identifier = "AdministrationPerspective")
 public class AdministrationPerspective {


### PR DESCRIPTION
Note: The Menus and Home Page sections already restrict features access by using KieACL.