### PR TITLE
- the kie.services.rest.deploy.async property is only valid in the 6.0.x

### DIFF
--- a/kie-wb/kie-wb-distribution-wars/src/main/assembly/was8/README.md
+++ b/kie-wb/kie-wb-distribution-wars/src/main/assembly/was8/README.md
@@ -139,7 +139,6 @@ JVM Custom properties
 **Additional JVM properties**
 - jbpm.ut.jndi.lookup  - jta/usertransaction -- allows to look up user transaction from within non managed threads, e.g. timers
 - kie.services.jms.queues.response - {JNDI_NAME} -- JNDI name of the response queue for JMS remote API
-- kie.services.rest.deploy.async - false -- instructs REST service to use synchronous mode to process deployments must be set for WebSphere due to issues with CDI on WAS 8.5
 
 Deploy the application
 --------------------------


### PR DESCRIPTION
@agiertli Thanks for the heads up!

@m-czernek Could you make sure the product documentation for 6.1, 6.2 and 6.3 reflects this change? Thanks!