### PR TITLE
GUVNOR-2504: Move Guvnor REST tests from QE test suite

### DIFF
--- a/kie-wb-tests/.gitignore
+++ b/kie-wb-tests/.gitignore
@@ -1,0 +1,11 @@
+target/
+local/
+
+# Eclipse, Netbeans and IntelliJ files
+/.*
+/**/.*
+!.gitignore
+/nbproject
+*.ipr
+*.iws
+*.iml

--- a/kie-wb-tests/README.md
+++ b/kie-wb-tests/README.md
@@ -1,0 +1,30 @@
+#KIE Workbench tests
+
+This module contains tests which require KIE Workbench to be running in order to be executed.
+
+##Running and debugging tests locally
+
+You can run tests directly from the command line.
+Cargo will take care of starting the container and the tests will be run afterwards.
+
+```
+mvn clean verify -Pkie-wb,wildfly10
+```
+
+In order to run the tests easily from IDE, the server (container) needs to be already running and the application be deployed.
+Following Maven command will start the Wildfly 10 and deploy the KIE Workbench WAR.
+The server will run until manually (Ctrl+C) stopped:
+
+```
+mvn clean package cargo:run -Pkie-wb,wildfly10
+```
+
+You can of course choose `kie-drools-wb` instead of `kie-wb` and also different container to deploy
+to (see the profiles in `pom.xml` for the list of supported containers).
+
+The base application URI is by default `http://localhost:8080/kie-wb`.
+Cargo also automatically configures the server (users, groups, etc).
+After executing the `cargo:run` the application is ready to be used.
+
+The last step is to update the property `kie.wb.url`.
+By default it is `http://localhost:8080/kie-wb`, but you can override it in case e.g. your server is running on different port.

--- a/kie-wb-tests/kie-wb-tests-rest/pom.xml
+++ b/kie-wb-tests/kie-wb-tests-rest/pom.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>kie-wb-tests</artifactId>
+    <groupId>org.kie</groupId>
+    <version>7.0.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>kie-wb-tests-rest</artifactId>
+
+  <name>KIE (Drools) Workbench Tests :: REST API</name>
+  <description>REST API tests for KIE Workbench and KIE Drools Workbench</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>commons-net</groupId>
+      <artifactId>commons-net</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpcore</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.jackson</groupId>
+      <artifactId>jackson-mapper-asl</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.guvnor</groupId>
+      <artifactId>guvnor-rest-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-jackson-provider</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-jaxrs</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.kie.remote</groupId>
+      <artifactId>kie-remote-jaxb</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.cargo</groupId>
+        <artifactId>cargo-maven2-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/kie-wb-tests/kie-wb-tests-rest/src/main/java/org/kie/wb/test/rest/User.java
+++ b/kie-wb-tests/kie-wb-tests-rest/src/main/java/org/kie/wb/test/rest/User.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.wb.test.rest;
+
+public enum User {
+
+    REST_ALL("restAll", "restAll1234;"),
+    REST_PROJECT("restProject", "restProject1234;"),
+    NO_REST("noRest", "noRest1234;");
+
+    private final String userName;
+    private final String password;
+
+    User(String userName, String password) {
+        this.userName = userName;
+        this.password = password;
+    }
+
+    public String getUserName() {
+        return userName;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+}

--- a/kie-wb-tests/kie-wb-tests-rest/src/main/java/org/kie/wb/test/rest/client/NotSuccessException.java
+++ b/kie-wb-tests/kie-wb-tests-rest/src/main/java/org/kie/wb/test/rest/client/NotSuccessException.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.wb.test.rest.client;
+
+import org.guvnor.rest.client.JobResult;
+
+public class NotSuccessException extends RuntimeException {
+
+    private final JobResult jobResult;
+
+    public NotSuccessException(JobResult jobResult) {
+        super(jobResult.getStatus() + ": " + jobResult.getResult());
+
+        this.jobResult = jobResult;
+    }
+
+    public JobResult getJobResult() {
+        return jobResult;
+    }
+
+}

--- a/kie-wb-tests/kie-wb-tests-rest/src/main/java/org/kie/wb/test/rest/client/RestWorkbenchClient.java
+++ b/kie-wb-tests/kie-wb-tests-rest/src/main/java/org/kie/wb/test/rest/client/RestWorkbenchClient.java
@@ -1,0 +1,346 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.wb.test.rest.client;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import javax.ws.rs.core.MediaType;
+
+import org.guvnor.rest.client.AddRepositoryToOrganizationalUnitRequest;
+import org.guvnor.rest.client.CompileProjectRequest;
+import org.guvnor.rest.client.CreateOrCloneRepositoryRequest;
+import org.guvnor.rest.client.CreateOrganizationalUnitRequest;
+import org.guvnor.rest.client.CreateProjectRequest;
+import org.guvnor.rest.client.DeleteProjectRequest;
+import org.guvnor.rest.client.DeployProjectRequest;
+import org.guvnor.rest.client.InstallProjectRequest;
+import org.guvnor.rest.client.JobRequest;
+import org.guvnor.rest.client.JobResult;
+import org.guvnor.rest.client.JobStatus;
+import org.guvnor.rest.client.OrganizationalUnit;
+import org.guvnor.rest.client.ProjectRequest;
+import org.guvnor.rest.client.ProjectResponse;
+import org.guvnor.rest.client.RemoveOrganizationalUnitRequest;
+import org.guvnor.rest.client.RemoveRepositoryFromOrganizationalUnitRequest;
+import org.guvnor.rest.client.RemoveRepositoryRequest;
+import org.guvnor.rest.client.RepositoryRequest;
+import org.guvnor.rest.client.RepositoryResponse;
+import org.guvnor.rest.client.TestProjectRequest;
+import org.guvnor.rest.client.UpdateOrganizationalUnit;
+import org.guvnor.rest.client.UpdateOrganizationalUnitRequest;
+import org.kie.wb.test.rest.util.HttpRequestFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class RestWorkbenchClient implements WorkbenchClient {
+
+    private static final Logger log = LoggerFactory.getLogger(RestWorkbenchClient.class);
+
+    private static final int JOB_TIMEOUT_SECONDS = 10;
+    private static final int PROJECT_JOB_TIMEOUT_SECONDS = 30;
+    private static final int CLONE_REPO_TIMEOUT_SECONDS = 60;
+
+    private static final MediaType DEFAULT_CONTENT_TYPE = MediaType.APPLICATION_JSON_TYPE;
+
+    private final HttpRequestFactory http;
+
+    private final boolean async;
+
+    private RestWorkbenchClient(String appUrl, String userId, String password, boolean async) {
+        http = new HttpRequestFactory(appUrl + "/rest/", userId, password, DEFAULT_CONTENT_TYPE);
+        this.async = async;
+    }
+
+    /**
+     * Creates KIE Workbench REST client which will execute each operation asynchronously. The status of the operation
+     * can be checked by retrieving the details about the job with ID provided in the request.
+     */
+    public static WorkbenchClient createAsyncWorkbenchClient(String appUrl, String userId, String password) {
+        return new RestWorkbenchClient(appUrl, userId, password, true);
+    }
+
+    /**
+     * Creates KIE Workbench REST client which will wait for completion of each operation.
+     */
+    public static WorkbenchClient createWorkbenchClient(String appUrl, String userId, String password) {
+        return new RestWorkbenchClient(appUrl, userId, password, false);
+    }
+
+    @Override
+    public JobResult getJob(String jobId) {
+        log.info("Getting job '{}'", jobId);
+
+        return http.request("jobs/" + jobId, JobResult.class).get();
+    }
+
+    @Override
+    public JobResult deleteJob(String jobId) {
+        log.info("Deleting job '{}'", jobId);
+
+        return http.request("jobs/" + jobId, JobResult.class).delete();
+    }
+
+    @Override
+    public Collection<RepositoryResponse> getRepositories() {
+        log.info("Getting all repositories");
+
+        Collection<Map<String, String>> result = http.request("repositories", Collection.class).get();
+
+        Collection<RepositoryResponse> repositories = new ArrayList<>();
+        for (Map<String, String> map : result) {
+            RepositoryResponse repository = new RepositoryResponse();
+            repository.setName(map.get("name"));
+            repository.setDescription(map.get("description"));
+            repository.setUserName(map.get("userName"));
+            repository.setPassword(map.get("password"));
+            repository.setRequestType(map.get("requestType"));
+            repository.setGitURL(map.get("gitURL"));
+            repositories.add(repository);
+        }
+
+        return repositories;
+    }
+
+    @Override
+    public RepositoryResponse getRepository(String repositoryName) {
+        log.info("Getting repository '{}'", repositoryName);
+
+        return http.request("repositories/" + repositoryName, RepositoryResponse.class).get();
+    }
+
+    @Override
+    public CreateOrCloneRepositoryRequest createOrCloneRepository(RepositoryRequest repository) {
+        log.info("Creating new repository '{}'", repository.getName());
+
+        CreateOrCloneRepositoryRequest request = http.request("repositories", CreateOrCloneRepositoryRequest.class)
+                .body(repository).post();
+
+        if (request.getRepository().getRequestType().equals("clone")) {
+            return waitUntilJobFinished(request, CLONE_REPO_TIMEOUT_SECONDS);
+        } else {
+            return waitUntilJobFinished(request);
+        }
+    }
+
+    @Override
+    public RemoveRepositoryRequest deleteRepository(String repositoryName) {
+        log.info("Deleting repository '{}'", repositoryName);
+
+        RemoveRepositoryRequest request = http.request("repositories/" + repositoryName, RemoveRepositoryRequest.class)
+                .delete();
+
+        return waitUntilJobFinished(request);
+    }
+
+    @Override
+    public CreateProjectRequest createProject(String repositoryName, ProjectRequest project) {
+        log.info("Creating project '{}' in repository '{}'", project.getName(), repositoryName);
+
+        CreateProjectRequest request = http.request("repositories/" + repositoryName + "/projects",
+                CreateProjectRequest.class).body(project).post();
+
+        return waitUntilJobFinished(request, PROJECT_JOB_TIMEOUT_SECONDS);
+    }
+
+    @Override
+    public DeleteProjectRequest deleteProject(String repositoryName, String projectName) {
+        log.info("Removing project '{}' from repository '{}'", projectName, repositoryName);
+
+        DeleteProjectRequest request = http.request("repositories/" + repositoryName + "/projects/" + projectName,
+                DeleteProjectRequest.class).delete();
+
+        return waitUntilJobFinished(request, PROJECT_JOB_TIMEOUT_SECONDS);
+    }
+
+    @Override
+    public Collection<ProjectResponse> getProjects(String repositoryName) {
+        log.info("Retrieving all projects from repository '{}'", repositoryName);
+
+        Collection<Map<String, String>> result = http.request("repositories/" + repositoryName + "/projects",
+                Collection.class).get();
+
+        Collection<ProjectResponse> projects = new ArrayList<>();
+        for (Map<String, String> map : result) {
+            ProjectResponse project = new ProjectResponse();
+            project.setName(map.get("name"));
+            project.setDescription(map.get("description"));
+            project.setGroupId(map.get("groupId"));
+            project.setVersion(map.get("version"));
+            projects.add(project);
+        }
+        return projects;
+    }
+
+    @Override
+    public Collection<OrganizationalUnit> getOrganizationalUnits() {
+        log.info("Getting all organizational units");
+
+        Collection<Map<String, Object>> result = http.request("organizationalunits", Collection.class).get();
+
+        Collection<OrganizationalUnit> orgUnits = new ArrayList<>();
+        for (Map<String, Object> map : result) {
+            OrganizationalUnit orgUnit = new OrganizationalUnit();
+            orgUnit.setName((String) map.get("name"));
+            orgUnit.setDescription((String) map.get("description"));
+            orgUnit.setOwner((String) map.get("owner"));
+            orgUnit.setDefaultGroupId((String) map.get("defaultGroupId"));
+            orgUnit.setRepositories((List<String>) map.get("repositories"));
+            orgUnits.add(orgUnit);
+        }
+        return orgUnits;
+    }
+
+    @Override
+    public CreateOrganizationalUnitRequest createOrganizationalUnit(OrganizationalUnit orgUnit) {
+        log.info("Creating organizational unit '{}' ", orgUnit.getName());
+
+        CreateOrganizationalUnitRequest request = http.request("organizationalunits",
+                CreateOrganizationalUnitRequest.class).body(orgUnit).post();
+
+        return waitUntilJobFinished(request);
+    }
+
+    @Override
+    public OrganizationalUnit getOrganizationalUnit(String name) {
+        log.info("Getting organizational unit '{}'", name);
+
+        return http.request("organizationalunits/" + name, OrganizationalUnit.class).get();
+    }
+
+    @Override
+    public UpdateOrganizationalUnitRequest updateOrganizationalUnit(String name, UpdateOrganizationalUnit orgUnit) {
+        log.info("Updating organizational unit '{}'", name);
+
+        UpdateOrganizationalUnitRequest request = http.request("organizationalunits/" + name,
+                UpdateOrganizationalUnitRequest.class).body(orgUnit).post();
+
+        return waitUntilJobFinished(request);
+    }
+
+    @Override
+    public RemoveOrganizationalUnitRequest deleteOrganizationalUnit(String name) {
+        log.info("Deleting organizational unit '{}'", name);
+
+        RemoveOrganizationalUnitRequest request = http.request("organizationalunits/" + name,
+                RemoveOrganizationalUnitRequest.class).delete();
+
+        return waitUntilJobFinished(request);
+    }
+
+    @Override
+    public AddRepositoryToOrganizationalUnitRequest addRepositoryToOrganizationalUnit(String orgUnitName,
+                                                                                      String repositoryName) {
+        log.info("Adding repository '{}' to organizational unit '{}'", repositoryName, orgUnitName);
+
+        AddRepositoryToOrganizationalUnitRequest request = http.request("organizationalunits/" + orgUnitName +
+                "/repositories/" + repositoryName, AddRepositoryToOrganizationalUnitRequest.class).post();
+
+        return waitUntilJobFinished(request);
+    }
+
+    @Override
+    public RemoveRepositoryFromOrganizationalUnitRequest removeRepositoryFromOrganizationalUnit(String orgUnitName,
+                                                                                                String repositoryName) {
+        log.info("Removing repository '{}' from organizational unit '{}'", repositoryName, orgUnitName);
+
+        RemoveRepositoryFromOrganizationalUnitRequest request = http.request("organizationalunits/" + orgUnitName +
+                "/repositories/" + repositoryName, RemoveRepositoryFromOrganizationalUnitRequest.class).delete();
+
+        return waitUntilJobFinished(request);
+    }
+
+    @Override
+    public CompileProjectRequest compileProject(String repositoryName, String projectName) {
+        log.info("Compiling project '{}' from repository '{}'", projectName, repositoryName);
+
+        CompileProjectRequest request = http.request("repositories/" + repositoryName + "/projects/" + projectName +
+                "/maven/compile", CompileProjectRequest.class).post();
+
+        return waitUntilJobFinished(request, PROJECT_JOB_TIMEOUT_SECONDS);
+    }
+
+    @Override
+    public InstallProjectRequest installProject(String repositoryName, String projectName) {
+        log.info("Installing project '{}' from repository '{}'", projectName, repositoryName);
+
+        InstallProjectRequest request = http.request("repositories/" + repositoryName + "/projects/" + projectName +
+                "/maven/install", InstallProjectRequest.class).post();
+
+        return waitUntilJobFinished(request, PROJECT_JOB_TIMEOUT_SECONDS);
+    }
+
+    @Override
+    public TestProjectRequest testProject(String repositoryName, String projectName) {
+        log.info("Testing project '{}' from repository '{}'", projectName, repositoryName);
+
+        TestProjectRequest request = http.request("repositories/" + repositoryName + "/projects/" + projectName +
+                "/maven/test", TestProjectRequest.class).post();
+
+        return waitUntilJobFinished(request, PROJECT_JOB_TIMEOUT_SECONDS);
+    }
+
+    @Override
+    public DeployProjectRequest deployProject(String repositoryName, String projectName) {
+        log.info("Deploying project '{}' from repository '{}'", projectName, repositoryName);
+
+        DeployProjectRequest request = http.request("repositories/" + repositoryName + "/projects/" + projectName +
+                "/maven/deploy", DeployProjectRequest.class).post();
+
+        return waitUntilJobFinished(request, PROJECT_JOB_TIMEOUT_SECONDS);
+    }
+
+    private <T extends JobRequest> T waitUntilJobFinished(T request) {
+        return waitUntilJobFinished(request, JOB_TIMEOUT_SECONDS);
+    }
+
+    private <T extends JobRequest> T waitUntilJobFinished(T request, int seconds) {
+        if (async) {
+            return request;
+        }
+
+        JobResult jobResult;
+        while ((jobResult = getJob(request.getJobId())).getStatus() != JobStatus.SUCCESS && seconds-- > 0) {
+            switch (jobResult.getStatus()) {
+                case ACCEPTED:
+                case APPROVED:
+                    sleepForSecond();
+                    break;
+                case SUCCESS:
+                    return request;
+                default:
+                    throw new NotSuccessException(jobResult);
+            }
+        }
+
+        if (jobResult.getStatus() != JobStatus.SUCCESS) {
+            throw new NotSuccessException(jobResult);
+        }
+
+        return request;
+    }
+
+    private void sleepForSecond() {
+        try {
+            Thread.sleep(1000); // TODO use something else
+        } catch (InterruptedException ex) {
+            // continue
+        }
+    }
+
+}

--- a/kie-wb-tests/kie-wb-tests-rest/src/main/java/org/kie/wb/test/rest/client/WorkbenchClient.java
+++ b/kie-wb-tests/kie-wb-tests-rest/src/main/java/org/kie/wb/test/rest/client/WorkbenchClient.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.wb.test.rest.client;
+
+import java.util.Collection;
+
+import org.guvnor.rest.client.AddRepositoryToOrganizationalUnitRequest;
+import org.guvnor.rest.client.CompileProjectRequest;
+import org.guvnor.rest.client.CreateOrCloneRepositoryRequest;
+import org.guvnor.rest.client.CreateOrganizationalUnitRequest;
+import org.guvnor.rest.client.CreateProjectRequest;
+import org.guvnor.rest.client.DeleteProjectRequest;
+import org.guvnor.rest.client.DeployProjectRequest;
+import org.guvnor.rest.client.InstallProjectRequest;
+import org.guvnor.rest.client.JobResult;
+import org.guvnor.rest.client.OrganizationalUnit;
+import org.guvnor.rest.client.ProjectRequest;
+import org.guvnor.rest.client.ProjectResponse;
+import org.guvnor.rest.client.RemoveOrganizationalUnitRequest;
+import org.guvnor.rest.client.RemoveRepositoryFromOrganizationalUnitRequest;
+import org.guvnor.rest.client.RemoveRepositoryRequest;
+import org.guvnor.rest.client.RepositoryRequest;
+import org.guvnor.rest.client.RepositoryResponse;
+import org.guvnor.rest.client.TestProjectRequest;
+import org.guvnor.rest.client.UpdateOrganizationalUnit;
+import org.guvnor.rest.client.UpdateOrganizationalUnitRequest;
+
+public interface WorkbenchClient {
+
+    /**
+     * [GET] /jobs/{jobID}
+     */
+    JobResult getJob(String jobId);
+
+    /**
+     * [DELETE] /jobs/{jobID}
+     */
+    JobResult deleteJob(String jobId);
+
+    /**
+     * [GET] /repositories
+     */
+    Collection<RepositoryResponse> getRepositories();
+
+    /**
+     * [GET] /repositories/{repositoryName}
+     */
+    RepositoryResponse getRepository(String repositoryName);
+
+    /**
+     * [POST] /repositories
+     */
+    CreateOrCloneRepositoryRequest createOrCloneRepository(RepositoryRequest repository);
+
+    /**
+     * [DELETE] /repositories/{repositoryName}
+     */
+    RemoveRepositoryRequest deleteRepository(String repositoryName);
+
+    /**
+     * [POST] /repositories/{repositoryName}/projects/
+     */
+    CreateProjectRequest createProject(String repositoryName, ProjectRequest project);
+
+    /**
+     * [DELETE] /repositories/{repositoryName}/projects/{projectName}
+     */
+    DeleteProjectRequest deleteProject(String repositoryName, String projectName);
+
+    /**
+     * [GET] /repositories/{repositoryName}/projects/
+     */
+    Collection<ProjectResponse> getProjects(String repositoryName);
+
+    /**
+     * [GET] /organizationalunits
+     */
+    Collection<OrganizationalUnit> getOrganizationalUnits();
+
+    /**
+     * [POST] /organizationalunits
+     */
+    CreateOrganizationalUnitRequest createOrganizationalUnit(OrganizationalUnit organizationalUnit);
+
+    /**
+     * [GET] /organizationalunits/{orgUnitName}
+     */
+    OrganizationalUnit getOrganizationalUnit(String orgUnitName);
+
+    /**
+     * [POST] /organizationalunits/{orgUnitName}
+     */
+    UpdateOrganizationalUnitRequest updateOrganizationalUnit(String name, UpdateOrganizationalUnit organizationalUnit);
+
+    /**
+     * [DELETE] /organizationalunits/{organizationalUnitName}
+     */
+    RemoveOrganizationalUnitRequest deleteOrganizationalUnit(String orgUnitName);
+
+    /**
+     * [POST] /organizationalunits/{organizationalUnitName}/repositories/{repositoryName}
+     */
+    AddRepositoryToOrganizationalUnitRequest addRepositoryToOrganizationalUnit(String orgUnitName,
+                                                                               String repositoryName);
+
+    /**
+     * [DELETE] /organizationalunits/{organizationalUnitName}/repositories/{repositoryName}
+     */
+    RemoveRepositoryFromOrganizationalUnitRequest removeRepositoryFromOrganizationalUnit(String orgUnitName,
+                                                                                         String repositoryName);
+
+    /**
+     * [POST] /repositories/{repositoryName}/projects/{projectName}/maven/compile
+     */
+    CompileProjectRequest compileProject(String repositoryName, String projectName);
+
+    /**
+     * [POST] /repositories/{repositoryName}/projects/{projectName}/maven/install
+     */
+    InstallProjectRequest installProject(String repositoryName, String projectName);
+
+    /**
+     * [POST] /repositories/{repositoryName}/projects/{projectName}/maven/test
+     */
+    TestProjectRequest testProject(String repositoryName, String projectName);
+
+    /**
+     * [POST] /repositories/{repositoryName}/projects/{projectName}/maven/deploy
+     */
+    DeployProjectRequest deployProject(String repositoryName, String projectName);
+
+}

--- a/kie-wb-tests/kie-wb-tests-rest/src/main/java/org/kie/wb/test/rest/exception/BadRequestException.java
+++ b/kie-wb-tests/kie-wb-tests-rest/src/main/java/org/kie/wb/test/rest/exception/BadRequestException.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.wb.test.rest.exception;
+
+public class BadRequestException extends RemoteException {
+
+    public BadRequestException(String message) {
+        super(400, "Bad Request", message);
+    }
+
+}

--- a/kie-wb-tests/kie-wb-tests-rest/src/main/java/org/kie/wb/test/rest/exception/ForbiddenException.java
+++ b/kie-wb-tests/kie-wb-tests-rest/src/main/java/org/kie/wb/test/rest/exception/ForbiddenException.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.wb.test.rest.exception;
+
+public class ForbiddenException extends RemoteException {
+
+    public ForbiddenException(String message) {
+        super(403, "Forbidden", message);
+    }
+
+}

--- a/kie-wb-tests/kie-wb-tests-rest/src/main/java/org/kie/wb/test/rest/exception/NotFoundException.java
+++ b/kie-wb-tests/kie-wb-tests-rest/src/main/java/org/kie/wb/test/rest/exception/NotFoundException.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.wb.test.rest.exception;
+
+public class NotFoundException extends RemoteException {
+
+    public NotFoundException(String message) {
+        super(404, "Not Found", message);
+    }
+
+}

--- a/kie-wb-tests/kie-wb-tests-rest/src/main/java/org/kie/wb/test/rest/exception/RemoteException.java
+++ b/kie-wb-tests/kie-wb-tests-rest/src/main/java/org/kie/wb/test/rest/exception/RemoteException.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.wb.test.rest.exception;
+
+public class RemoteException extends RuntimeException {
+
+    private final int code;
+
+    public RemoteException(int code, String message) {
+        super(code + " " + message);
+
+        this.code = code;
+    }
+
+    public RemoteException(int code, String reason, String message) {
+        this(code, reason + "\n" + message);
+    }
+
+    public int getCode() {
+        return code;
+    }
+
+}

--- a/kie-wb-tests/kie-wb-tests-rest/src/main/java/org/kie/wb/test/rest/exception/UnauthorizedException.java
+++ b/kie-wb-tests/kie-wb-tests-rest/src/main/java/org/kie/wb/test/rest/exception/UnauthorizedException.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.wb.test.rest.exception;
+
+public class UnauthorizedException extends RemoteException {
+
+    public UnauthorizedException(String message) {
+        super(401, "Unauthorized", message);
+    }
+
+}

--- a/kie-wb-tests/kie-wb-tests-rest/src/main/java/org/kie/wb/test/rest/util/HttpRequest.java
+++ b/kie-wb-tests/kie-wb-tests-rest/src/main/java/org/kie/wb/test/rest/util/HttpRequest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.wb.test.rest.util;
+
+import java.io.IOException;
+import javax.ws.rs.core.MediaType;
+
+import org.codehaus.jackson.map.ObjectMapper;
+import org.jboss.resteasy.client.ClientRequest;
+import org.jboss.resteasy.client.ClientResponse;
+import org.jboss.resteasy.client.core.BaseClientResponse;
+import org.jboss.resteasy.spi.ReaderException;
+import org.kie.wb.test.rest.exception.BadRequestException;
+import org.kie.wb.test.rest.exception.ForbiddenException;
+import org.kie.wb.test.rest.exception.NotFoundException;
+import org.kie.wb.test.rest.exception.RemoteException;
+import org.kie.wb.test.rest.exception.UnauthorizedException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class HttpRequest<T> {
+
+    private static final Logger log = LoggerFactory.getLogger(HttpRequest.class);
+
+    private final ClientRequest request;
+    private final Class<T> returnType;
+
+    private Object body;
+    private MediaType contentType;
+
+    public HttpRequest(ClientRequest request, Class<T> returnType, MediaType contentType) {
+        this.request = request;
+        this.returnType = returnType;
+        this.contentType = contentType;
+    }
+
+    public HttpRequest<T> contentType(MediaType contentType) {
+        this.contentType = contentType;
+        return this;
+    }
+
+    public HttpRequest<T> body(Object body) {
+        this.body = serializeEntity(body);
+        return this;
+    }
+
+    public T get() {
+        return call(() -> request.get(returnType));
+    }
+
+    public T post() {
+        if (body != null) {
+            request.body(contentType, body);
+        }
+        return call(() -> request.post(returnType));
+    }
+
+    public T delete() {
+        return call(() -> request.delete(returnType));
+    }
+
+    private T call(HttpMethod<T> httpMethod) {
+        request.accept(contentType);
+
+        ClientResponse<T> response = null;
+        try {
+            response = sendRequest(httpMethod);
+            checkResponse(response);
+            return response.getEntity();
+        } finally {
+            if (response != null) {
+                response.releaseConnection();
+            }
+        }
+    }
+
+    private ClientResponse<T> sendRequest(HttpMethod<T> httpMethod) {
+        try {
+            return httpMethod.sendRequest();
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    private void checkResponse(ClientResponse<T> originalResponse) {
+        ClientResponse<?> response = BaseClientResponse.copyFromError(originalResponse);
+        originalResponse.resetStream();
+
+        String entity = "";
+        try {
+            entity = response.getEntity(String.class);
+        } catch (ReaderException ex) {
+            // sometimes the entity is empty and we do not want to see this exception at all
+        }
+
+        switch (response.getResponseStatus()) {
+            case OK:
+            case CREATED:
+            case ACCEPTED:
+            case NO_CONTENT:
+                log.info(entity);
+                return;
+            case BAD_REQUEST:
+                throw new BadRequestException(entity);
+            case UNAUTHORIZED:
+                throw new UnauthorizedException(entity);
+            case FORBIDDEN:
+                throw new ForbiddenException(entity);
+            case NOT_FOUND:
+                throw new NotFoundException(entity);
+            default:
+                throw new RemoteException(response.getResponseStatus().getStatusCode(), entity);
+        }
+    }
+
+    private String serializeEntity(Object entity) {
+        try {
+            return new ObjectMapper().writeValueAsString(entity);
+        } catch (IOException ex) {
+            throw new RuntimeException("Unable to serialize " + entity.getClass().getSimpleName(), ex);
+        }
+    }
+
+    @FunctionalInterface
+    private interface HttpMethod<T> {
+
+        ClientResponse<T> sendRequest() throws Exception;
+
+    }
+
+}

--- a/kie-wb-tests/kie-wb-tests-rest/src/main/java/org/kie/wb/test/rest/util/HttpRequestFactory.java
+++ b/kie-wb-tests/kie-wb-tests-rest/src/main/java/org/kie/wb/test/rest/util/HttpRequestFactory.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.wb.test.rest.util;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import javax.ws.rs.core.MediaType;
+
+import org.apache.commons.net.util.Base64;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.client.HttpClient;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.jboss.resteasy.client.ClientExecutor;
+import org.jboss.resteasy.client.ClientRequest;
+import org.jboss.resteasy.client.ClientRequestFactory;
+import org.jboss.resteasy.client.core.executors.ApacheHttpClient4Executor;
+import org.jboss.resteasy.spi.ResteasyProviderFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class HttpRequestFactory {
+
+    private static final Logger log = LoggerFactory.getLogger(HttpRequestFactory.class);
+
+    private final String url;
+    private final MediaType defaultContentType;
+
+    private final String authHeader;
+    private final ClientRequestFactory clientRequestFactory;
+
+
+    public HttpRequestFactory(String url, String userId, String password, MediaType defaultContentType) {
+        this.url = url;
+        this.defaultContentType = defaultContentType;
+
+        this.authHeader = createAuthHeader(userId, password);
+        this.clientRequestFactory = createClientRequestFactory(userId, password);
+    }
+
+    private static String createAuthHeader(String userId, String password) {
+        return "Basic " + Base64.encodeBase64String(String.format("%s:%s", userId, password).getBytes()).trim();
+    }
+
+    private static ClientRequestFactory createClientRequestFactory(String userId, String password) {
+        CredentialsProvider cp = new BasicCredentialsProvider();
+        cp.setCredentials(new AuthScope(AuthScope.ANY_HOST, AuthScope.ANY_PORT, AuthScope.ANY_REALM),
+                new UsernamePasswordCredentials(userId, password));
+
+        HttpClient httpClient = HttpClientBuilder.create()
+                .setDefaultCredentialsProvider(cp)
+                .build();
+        ClientExecutor clientExecutor = new ApacheHttpClient4Executor(httpClient);
+
+        return new ClientRequestFactory(clientExecutor, ResteasyProviderFactory.getInstance());
+    }
+
+    private ClientRequest createClientRequest(String path) {
+        try {
+            String address = new URL(url + path).toExternalForm();
+            log.debug(address);
+
+            return clientRequestFactory.createRequest(address)
+                    .header("Authorization", authHeader)
+                    .followRedirects(true);
+        } catch (MalformedURLException ex) {
+            throw new RuntimeException("Invalid path", ex);
+        }
+    }
+
+    public <T> HttpRequest<T> request(String path, Class<T> returnType) {
+        return new HttpRequest<>(createClientRequest(path), returnType, defaultContentType);
+    }
+
+}

--- a/kie-wb-tests/kie-wb-tests-rest/src/test/java/org/kie/wb/test/rest/RestTestBase.java
+++ b/kie-wb-tests/kie-wb-tests-rest/src/test/java/org/kie/wb/test/rest/RestTestBase.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.wb.test.rest;
+
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.rules.TestRule;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
+import org.kie.wb.test.rest.client.RestWorkbenchClient;
+import org.kie.wb.test.rest.client.WorkbenchClient;
+import qa.tools.ikeeper.client.JiraClient;
+import qa.tools.ikeeper.test.IKeeperJUnitConnector;
+
+public abstract class RestTestBase {
+
+    private static final String URL = System.getProperty("kie.wb.url", "http://localhost:8080/kie-wb");
+    protected static final String USER_ID = System.getProperty("kie.wb.user.name", User.REST_ALL.getUserName());
+    private static final String PASSWORD = System.getProperty("kie.wb.user.password", User.REST_ALL.getPassword());
+
+    protected static WorkbenchClient client;
+
+    @BeforeClass
+    public static void createWorkbenchClient() {
+        client = RestWorkbenchClient.createWorkbenchClient(URL, USER_ID, PASSWORD);
+    }
+
+    @Rule
+    public TestRule watcher = new TestWatcher() {
+
+        @Override
+        protected void starting(Description description) {
+            System.out.println(" >>> " + description.getMethodName() + " <<< ");
+        }
+
+        @Override
+        protected void finished(Description description) {
+            System.out.println();
+        }
+
+    };
+
+    @Rule
+    public IKeeperJUnitConnector issueKeeper = new IKeeperJUnitConnector(new JiraClient("https://issues.jboss.org"));
+
+    protected static void deleteAllOrganizationalUnits() {
+        client.getOrganizationalUnits().forEach(orgUnit -> client.deleteOrganizationalUnit(orgUnit.getName()));
+    }
+
+    protected static void deleteAllRepositories() {
+        client.getRepositories().forEach(repository -> client.deleteRepository(repository.getName()));
+    }
+
+}

--- a/kie-wb-tests/kie-wb-tests-rest/src/test/java/org/kie/wb/test/rest/functional/JobIntegrationTest.java
+++ b/kie-wb-tests/kie-wb-tests-rest/src/test/java/org/kie/wb/test/rest/functional/JobIntegrationTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.wb.test.rest.functional;
+
+import org.assertj.core.api.Assertions;
+import org.guvnor.rest.client.JobRequest;
+import org.guvnor.rest.client.JobResult;
+import org.guvnor.rest.client.JobStatus;
+import org.guvnor.rest.client.OrganizationalUnit;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.kie.wb.test.rest.RestTestBase;
+
+public class JobIntegrationTest extends RestTestBase {
+
+    @BeforeClass
+    public static void preCleanUp() {
+        deleteAllOrganizationalUnits();
+    }
+
+    @AfterClass
+    public static void postCleanUp() {
+        deleteAllOrganizationalUnits();
+    }
+
+    @Test
+    public void testGetAndDelete() {
+        OrganizationalUnit orgUnit = new OrganizationalUnit();
+        orgUnit.setName("deleteJobOrgUnit");
+        orgUnit.setOwner(USER_ID);
+        JobRequest jobRequest = client.createOrganizationalUnit(orgUnit);
+
+        JobResult jobResult = client.getJob(jobRequest.getJobId());
+        Assertions.assertThat(jobResult.getStatus()).isNotEqualTo(JobStatus.GONE);
+
+        jobResult = client.deleteJob(jobRequest.getJobId());
+        Assertions.assertThat(jobResult.getStatus()).isEqualTo(JobStatus.GONE);
+    }
+
+    @Test
+    public void testDeleteNotExisting() {
+        JobResult jobResult = client.deleteJob("notExistingJob");
+        Assertions.assertThat(jobResult.getStatus()).isEqualTo(JobStatus.GONE);
+    }
+
+    @Test
+    public void testGetNotExisting() {
+        JobResult jobResult = client.getJob("notExistingJob");
+        Assertions.assertThat(jobResult.getStatus()).isEqualTo(JobStatus.GONE);
+    }
+
+}

--- a/kie-wb-tests/kie-wb-tests-rest/src/test/java/org/kie/wb/test/rest/functional/OrganizationalUnitIntegrationTest.java
+++ b/kie-wb-tests/kie-wb-tests-rest/src/test/java/org/kie/wb/test/rest/functional/OrganizationalUnitIntegrationTest.java
@@ -1,0 +1,458 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.wb.test.rest.functional;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.SoftAssertions;
+import org.guvnor.rest.client.CreateOrganizationalUnitRequest;
+import org.guvnor.rest.client.JobStatus;
+import org.guvnor.rest.client.OrganizationalUnit;
+import org.guvnor.rest.client.RepositoryRequest;
+import org.guvnor.rest.client.UpdateOrganizationalUnit;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.kie.wb.test.rest.RestTestBase;
+import org.kie.wb.test.rest.User;
+import org.kie.wb.test.rest.client.NotSuccessException;
+import org.kie.wb.test.rest.exception.NotFoundException;
+import qa.tools.ikeeper.annotation.Jira;
+
+public class OrganizationalUnitIntegrationTest extends RestTestBase {
+
+    private static final String DESCRIPTION = "Testing organizational unit";
+    private static final String GROUP_ID = "org.kie.wb.test";
+    private static final String OWNER = USER_ID;
+
+    private static final String DESCRIPTION2 = "Modified testing organizational unit";
+    private static final String GROUP_ID2 = "org.kie.wb.test.other";
+    private static final String OWNER2 = User.NO_REST.getUserName();
+
+    @BeforeClass
+    public static void preCleanUp() {
+        deleteAllRepositories();
+        deleteAllOrganizationalUnits();
+    }
+
+    @AfterClass
+    public static void postCleanUp() {
+        deleteAllRepositories();
+        deleteAllOrganizationalUnits();
+    }
+
+    @Test
+    public void testCreateEmptyName() {
+        OrganizationalUnit orgUnit = new OrganizationalUnit();
+        orgUnit.setOwner(OWNER);
+
+        try {
+            client.createOrganizationalUnit(orgUnit);
+            Assertions.fail("NotSuccessException should have been thrown");
+        } catch (NotSuccessException ex) {
+            Assertions.assertThat(ex.getJobResult().getStatus()).isEqualTo(JobStatus.BAD_REQUEST);
+            Assertions.assertThat(ex.getJobResult().getResult()).contains("name");
+        }
+    }
+
+    @Test
+    public void testCreateEmptyOwner() {
+        OrganizationalUnit orgUnit = new OrganizationalUnit();
+        orgUnit.setName("emptyOwnerOrgUnit");
+
+        try {
+            client.createOrganizationalUnit(orgUnit);
+            Assertions.fail("NotSuccessException should have been thrown");
+        } catch (NotSuccessException ex) {
+            Assertions.assertThat(ex.getJobResult().getStatus()).isEqualTo(JobStatus.BAD_REQUEST);
+            Assertions.assertThat(ex.getJobResult().getResult()).contains("owner");
+        }
+    }
+
+    @Test
+    public void testCreateMinimal() {
+        OrganizationalUnit orgUnit = new OrganizationalUnit();
+        orgUnit.setName("minimalOrgUnit");
+        orgUnit.setOwner(OWNER);
+
+        testCreate(orgUnit);
+    }
+
+    @Test
+    @Jira("GUVNOR-2542")
+    public void testCreateWithDescription() {
+        OrganizationalUnit orgUnit = new OrganizationalUnit();
+        orgUnit.setName("orgUnitWithDescription");
+        orgUnit.setOwner(OWNER);
+        orgUnit.setDescription(DESCRIPTION);
+
+        testCreate(orgUnit);
+    }
+
+    @Test
+    public void testCreateWithGroupId() {
+        OrganizationalUnit orgUnit = new OrganizationalUnit();
+        orgUnit.setName("orgUnitWithGroupId");
+        orgUnit.setOwner(OWNER);
+        orgUnit.setDefaultGroupId(GROUP_ID);
+
+        testCreate(orgUnit);
+    }
+
+    @Test
+    public void testCreateWithRepositories() {
+        final String originOrgUnitName = "originRepositoryOrgUnit";
+        prepareOrganizationalUnit(originOrgUnitName);
+
+        final String repositoryName1 = "orgUnitRepository1";
+        RepositoryRequest repository = new RepositoryRequest();
+        repository.setName(repositoryName1);
+        repository.setOrganizationalUnitName(originOrgUnitName);
+        repository.setRequestType("new");
+        client.createOrCloneRepository(repository);
+
+        final String repositoryName2 = "orgUnitRepository2";
+        RepositoryRequest repository2 = new RepositoryRequest();
+        repository2.setName(repositoryName2);
+        repository2.setOrganizationalUnitName(originOrgUnitName);
+        repository2.setRequestType("new");
+        client.createOrCloneRepository(repository2);
+
+        List<String> repositories = new ArrayList<>();
+        repositories.add(repositoryName1);
+        repositories.add(repositoryName2);
+
+        OrganizationalUnit orgUnit = new OrganizationalUnit();
+        orgUnit.setName("orgUnitWithRepositories");
+        orgUnit.setOwner(OWNER);
+        orgUnit.setRepositories(repositories);
+
+        testCreate(orgUnit);
+    }
+
+    @Test(expected = NotFoundException.class)
+    public void testUpdateNotExisting() {
+        UpdateOrganizationalUnit updateOrgUnit = new UpdateOrganizationalUnit();
+        updateOrgUnit.setOwner(OWNER2);
+        client.updateOrganizationalUnit("notExistingOrgUnit", updateOrgUnit);
+    }
+
+    @Test
+    @Jira("GUVNOR-2542")
+    public void testUpdateName() {
+        String oldName = "nameToBeChangedOrgUnit";
+        String newName = "nameChangedOrgUnit";
+        prepareOrganizationalUnit(oldName);
+
+        UpdateOrganizationalUnit updateOrgUnit = new UpdateOrganizationalUnit();
+        updateOrgUnit.setName(newName);
+        client.updateOrganizationalUnit(oldName, updateOrgUnit);
+
+        OrganizationalUnit orgUnit = client.getOrganizationalUnit(newName);
+        Assertions.assertThat(orgUnit).isNotNull();
+    }
+
+    @Test
+    public void testUpdateOwner() {
+        String name = "ownerChangeOrgUnit";
+        prepareOrganizationalUnit(name);
+
+        UpdateOrganizationalUnit updateOrgUnit = new UpdateOrganizationalUnit();
+        updateOrgUnit.setOwner(OWNER2);
+        client.updateOrganizationalUnit(name, updateOrgUnit);
+
+        OrganizationalUnit orgUnit = client.getOrganizationalUnit(name);
+        Assertions.assertThat(orgUnit.getOwner()).isEqualTo(OWNER2);
+    }
+
+    @Test
+    @Jira("GUVNOR-2542")
+    public void testUpdateDescription() {
+        String name = "descriptionChangeOrgUnit";
+        prepareOrganizationalUnit(name);
+
+        UpdateOrganizationalUnit updateOrgUnit = new UpdateOrganizationalUnit();
+        updateOrgUnit.setDescription(DESCRIPTION2);
+        client.updateOrganizationalUnit(name, updateOrgUnit);
+
+        OrganizationalUnit orgUnit = client.getOrganizationalUnit(name);
+        Assertions.assertThat(orgUnit.getDescription()).isEqualTo(DESCRIPTION2);
+    }
+
+    @Test
+    public void testUpdateGroupId() {
+        String name = "groupIdChangeOrgUnit";
+        prepareOrganizationalUnit(name);
+
+        UpdateOrganizationalUnit updateOrgUnit = new UpdateOrganizationalUnit();
+        updateOrgUnit.setDefaultGroupId(GROUP_ID2);
+        client.updateOrganizationalUnit(name, updateOrgUnit);
+
+        OrganizationalUnit orgUnit = client.getOrganizationalUnit(name);
+        Assertions.assertThat(orgUnit.getDefaultGroupId()).isEqualTo(GROUP_ID2);
+    }
+
+    @Test(expected = NotFoundException.class)
+    public void testDeleteNotExisting() {
+        client.deleteOrganizationalUnit("notExistingOrgUnit");
+    }
+
+    @Test
+    public void testDeleteExisting() {
+        String name = "orgUnitToBeDeleted";
+        prepareOrganizationalUnit(name);
+
+        client.deleteOrganizationalUnit(name);
+
+        try {
+            client.getOrganizationalUnit(name);
+            Assertions.fail("Organizational unit should have been deleted");
+        } catch (NotFoundException ex) {
+            // expected
+        }
+    }
+
+    @Test(expected = NotFoundException.class)
+    public void testGetNotExisting() {
+        client.getOrganizationalUnit("notExistingOrgUnit");
+    }
+
+    @Test
+    public void testGetExisting() {
+        String name = "getExistingOrgUnit";
+        prepareOrganizationalUnit(name);
+
+        OrganizationalUnit orgUnit = client.getOrganizationalUnit(name);
+        Assertions.assertThat(orgUnit.getName()).isEqualTo(name);
+    }
+
+    @Test
+    public void testGetAll() {
+        String name = "oneOfManyOrgUnit";
+        prepareOrganizationalUnit(name);
+
+        Collection<OrganizationalUnit> orgUnits = client.getOrganizationalUnits();
+        Assertions.assertThat(orgUnits).extracting(OrganizationalUnit::getName).contains(name);
+    }
+
+    @Test
+    public void testAddRepositoryToNotExistingOrganizationalUnit() {
+        String orgUnitName = "addToNotExistingOrgUnit";
+        prepareOrganizationalUnit(orgUnitName);
+
+        RepositoryRequest repository = new RepositoryRequest();
+        repository.setName("addToNotExistingOrgUnitRepo");
+        repository.setOrganizationalUnitName(orgUnitName);
+        repository.setRequestType("new");
+        client.createOrCloneRepository(repository);
+
+        try {
+            client.addRepositoryToOrganizationalUnit("notExistingOrgUnit", repository.getName());
+            Assertions.fail("The operation should have failed because organizational unit does not exist");
+        } catch (NotFoundException ex) {
+            // expected
+        }
+    }
+
+    @Test
+    public void testAddNotExistingRepositoryToOrganizationalUnit() {
+        String orgUnitName = "addToNotExistingRepoOrgUnit";
+        prepareOrganizationalUnit(orgUnitName);
+
+        try {
+            client.addRepositoryToOrganizationalUnit(orgUnitName, "notExistingRepo");
+            Assertions.fail("The operation should have failed because repository does not exist");
+        } catch (NotFoundException ex) {
+            // expected
+        }
+    }
+
+    @Test
+    @Jira("GUVNOR-2542")
+    public void testAddRepositoryToOrganizationalUnitAlreadyAdded() {
+        String orgUnitName = "alreadyAddedRepoOrgUnit";
+        prepareOrganizationalUnit(orgUnitName);
+
+        String repoName = "alreadyAddedRepo";
+        RepositoryRequest repository = new RepositoryRequest();
+        repository.setName(repoName);
+        repository.setOrganizationalUnitName(orgUnitName);
+        repository.setRequestType("new");
+        client.createOrCloneRepository(repository);
+
+        try {
+            client.addRepositoryToOrganizationalUnit(orgUnitName, repoName);
+            Assertions.fail("The operation should not have succeeded");
+        } catch (NotSuccessException ex) {
+            Assertions.assertThat(ex.getJobResult().getStatus()).isEqualTo(JobStatus.BAD_REQUEST);
+        }
+    }
+
+    @Test
+    public void testAddRepositoryToOrganizationalUnit() {
+        String originOrgUnitName = "originAddRepoOrgUnit";
+        prepareOrganizationalUnit(originOrgUnitName);
+
+        String repoName = "addToOrgUnitRepo";
+        RepositoryRequest repository = new RepositoryRequest();
+        repository.setName(repoName);
+        repository.setOrganizationalUnitName(originOrgUnitName);
+        repository.setRequestType("new");
+        client.createOrCloneRepository(repository);
+
+        String orgUnitName = "addRepoOrgUnit";
+        prepareOrganizationalUnit(orgUnitName);
+
+        client.addRepositoryToOrganizationalUnit(orgUnitName, repoName);
+
+        OrganizationalUnit orgUnit = client.getOrganizationalUnit(orgUnitName);
+        Assertions.assertThat(orgUnit.getRepositories()).contains(repoName);
+    }
+
+    @Test
+    public void testRemoveRepositoryFromNotExistingOrganizationalUnit() {
+        String orgUnitName = "removeFromNotExistingOrgUnit";
+        prepareOrganizationalUnit(orgUnitName);
+
+        RepositoryRequest repository = new RepositoryRequest();
+        repository.setName("removeFromNotExistingOrgUnitRepo");
+        repository.setOrganizationalUnitName(orgUnitName);
+        repository.setRequestType("new");
+        client.createOrCloneRepository(repository);
+
+        try {
+            client.removeRepositoryFromOrganizationalUnit("notExistingOrgUnit", repository.getName());
+            Assertions.fail("The operation should have failed because organizational unit does not exist");
+        } catch (NotFoundException ex) {
+            // expected
+        }
+    }
+
+    @Test
+    public void testRemoveNotExistingRepositoryFromOrganizationalUnit() {
+        String orgUnitName = "removeFromNotExistingRepoOrgUnit";
+        prepareOrganizationalUnit(orgUnitName);
+
+        try {
+            client.addRepositoryToOrganizationalUnit(orgUnitName, "notExistingRepo");
+            Assertions.fail("The operation should have failed because repository does not exist");
+        } catch (NotFoundException ex) {
+            // expected
+        }
+    }
+
+    @Test
+    @Jira("GUVNOR-2542")
+    public void testRemoveNotAddedRepositoryFromOrganizationalUnit() {
+        String originOrgUnitName = "originRemoveFromNotAddedOrgUnit";
+        prepareOrganizationalUnit(originOrgUnitName);
+
+        String repoName = "removeFromNotAddedRepo";
+        RepositoryRequest repository = new RepositoryRequest();
+        repository.setName(repoName);
+        repository.setOrganizationalUnitName(originOrgUnitName);
+        repository.setRequestType("new");
+        client.createOrCloneRepository(repository);
+
+        String orgUnitName = "removeFromNotAddedOrgUnit";
+        prepareOrganizationalUnit(orgUnitName);
+
+        try {
+            client.removeRepositoryFromOrganizationalUnit(orgUnitName, repoName);
+            Assertions.fail("Operation should have failed");
+        } catch (NotSuccessException ex) {
+            Assertions.assertThat(ex.getJobResult().getStatus()).isEqualTo(JobStatus.BAD_REQUEST);
+        }
+    }
+
+    @Test
+    public void testRemoveRepositoryFromOrganizationalUnit() {
+        String orgUnitName = "originRemoveFromOrgUnit";
+        prepareOrganizationalUnit(orgUnitName);
+
+        String repoName = "removeFromOrgUnitRepo";
+        RepositoryRequest repository = new RepositoryRequest();
+        repository.setName(repoName);
+        repository.setOrganizationalUnitName(orgUnitName);
+        repository.setRequestType("new");
+        client.createOrCloneRepository(repository);
+
+        client.removeRepositoryFromOrganizationalUnit(orgUnitName, repoName);
+
+        OrganizationalUnit orgUnit = client.getOrganizationalUnit(orgUnitName);
+        Assertions.assertThat(orgUnit.getRepositories()).doesNotContain(repoName);
+    }
+
+    private OrganizationalUnit prepareOrganizationalUnit(String name) {
+        OrganizationalUnit orgUnit = new OrganizationalUnit();
+        orgUnit.setName(name);
+        orgUnit.setOwner(OWNER);
+        orgUnit.setDescription(DESCRIPTION);
+        orgUnit.setDefaultGroupId(GROUP_ID);
+
+        client.createOrganizationalUnit(orgUnit);
+
+        OrganizationalUnit storedOrgUnit = client.getOrganizationalUnit(name);
+        Assertions.assertThat(storedOrgUnit).isNotNull();
+
+        return orgUnit;
+    }
+
+    private void assertCreateOrganizationalUnitRequest(CreateOrganizationalUnitRequest request,
+                                                       OrganizationalUnit orgUnit) {
+        SoftAssertions assertions = new SoftAssertions();
+        assertions.assertThat(request.getOrganizationalUnitName()).isEqualTo(orgUnit.getName());
+        assertions.assertThat(request.getDescription()).isEqualTo(orgUnit.getDescription());
+        assertions.assertThat(request.getOwner()).isEqualTo(orgUnit.getOwner());
+        assertions.assertThat(request.getDefaultGroupId()).isEqualTo(orgUnit.getDefaultGroupId());
+        if (orgUnit.getRepositories() != null) {
+            assertions.assertThat(request.getRepositories())
+                    .containsOnly(orgUnit.getRepositories().toArray(new String[]{}));
+        }
+        assertions.assertAll();
+    }
+
+    private void assertOrganizationalUnit(OrganizationalUnit actual, OrganizationalUnit expected) {
+        if (expected.getDefaultGroupId() == null) {
+            expected.setDefaultGroupId(expected.getName());
+        }
+
+        SoftAssertions assertions = new SoftAssertions();
+        assertions.assertThat(actual.getName()).isEqualTo(expected.getName());
+        assertions.assertThat(actual.getDescription()).isEqualTo(expected.getDescription());
+        assertions.assertThat(actual.getOwner()).isEqualTo(expected.getOwner());
+        assertions.assertThat(actual.getDefaultGroupId()).isEqualTo(expected.getDefaultGroupId());
+        if (expected.getRepositories() != null) {
+            assertions.assertThat(actual.getRepositories())
+                    .containsOnly(expected.getRepositories().toArray(new String[]{}));
+        }
+        assertions.assertAll();
+
+    }
+
+    private void testCreate(OrganizationalUnit organizationalUnit) {
+        CreateOrganizationalUnitRequest request = client.createOrganizationalUnit(organizationalUnit);
+        assertCreateOrganizationalUnitRequest(request, organizationalUnit);
+
+        OrganizationalUnit orgUnit = client.getOrganizationalUnit(organizationalUnit.getName());
+        assertOrganizationalUnit(orgUnit, organizationalUnit);
+    }
+
+}

--- a/kie-wb-tests/kie-wb-tests-rest/src/test/java/org/kie/wb/test/rest/functional/ProjectIntegrationTest.java
+++ b/kie-wb-tests/kie-wb-tests-rest/src/test/java/org/kie/wb/test/rest/functional/ProjectIntegrationTest.java
@@ -1,0 +1,285 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.wb.test.rest.functional;
+
+import java.util.Collection;
+
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.SoftAssertions;
+import org.guvnor.rest.client.CompileProjectRequest;
+import org.guvnor.rest.client.CreateProjectRequest;
+import org.guvnor.rest.client.DeleteProjectRequest;
+import org.guvnor.rest.client.DeployProjectRequest;
+import org.guvnor.rest.client.InstallProjectRequest;
+import org.guvnor.rest.client.JobStatus;
+import org.guvnor.rest.client.OrganizationalUnit;
+import org.guvnor.rest.client.ProjectRequest;
+import org.guvnor.rest.client.ProjectResponse;
+import org.guvnor.rest.client.RepositoryRequest;
+import org.guvnor.rest.client.TestProjectRequest;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.kie.wb.test.rest.RestTestBase;
+import org.kie.wb.test.rest.client.NotSuccessException;
+import org.kie.wb.test.rest.exception.NotFoundException;
+import qa.tools.ikeeper.annotation.Jira;
+
+import static org.assertj.core.api.Assertions.*;
+
+public class ProjectIntegrationTest extends RestTestBase {
+
+    private static final String ORG_UNIT = "projectTestOrgUnit";
+    private static final String REPOSITORY = "projectTestRepository";
+
+    private static final String DESCRIPTION = "Testing project";
+    private static final String GROUP_ID = "org.kie.wb.test";
+    private static final String VERSION = "1.0.0";
+    private static final String SNAPSHOT_VERSION = "1.0.0-SNAPSHOT";
+
+    private static final String DEFAULT_VERSION = "1.0";
+
+    @BeforeClass
+    public static void setUp() {
+        OrganizationalUnit orgUnit = new OrganizationalUnit();
+        orgUnit.setName(ORG_UNIT);
+        orgUnit.setOwner(USER_ID);
+        client.createOrganizationalUnit(orgUnit);
+
+        RepositoryRequest repository = new RepositoryRequest();
+        repository.setName(REPOSITORY);
+        repository.setOrganizationalUnitName(ORG_UNIT);
+        repository.setRequestType("new");
+        client.createOrCloneRepository(repository);
+    }
+
+    @AfterClass
+    public static void cleanUp() {
+        client.deleteRepository(REPOSITORY);
+        client.deleteOrganizationalUnit(ORG_UNIT);
+    }
+
+    @Test
+    @Jira("GUVNOR-2542")
+    public void testCreateProjectWithoutName() {
+        ProjectRequest project = new ProjectRequest();
+        project.setGroupId(GROUP_ID);
+        project.setVersion(VERSION);
+
+        try {
+            client.createProject(REPOSITORY, project);
+        } catch (NotSuccessException ex) {
+            assertThat(ex.getJobResult().getStatus()).isEqualTo(JobStatus.BAD_REQUEST);
+            assertThat(ex.getJobResult().getResult()).contains("name");
+        }
+    }
+
+    @Test
+    public void testCreateProjectMinimal() {
+        createProject("minimalProject", null, null, null);
+    }
+
+    @Test
+    public void testCreateProjectWithDescription() {
+        createProject("projectWithDescription", DESCRIPTION, null, null);
+    }
+
+    @Test
+    public void testCreateProjectWithGroupId() {
+        createProject("projectWithGroupId", null, GROUP_ID, null);
+    }
+
+    @Test
+    public void testCreateProjectWithVersion() {
+        createProject("projectWithoutVersion", null, null, VERSION);
+    }
+
+    @Jira("GUVNOR-2542")
+    @Test(expected = NotFoundException.class)
+    public void testDeleteNotExistingProject() {
+        try {
+            client.deleteProject(REPOSITORY, "notExistingProject");
+        } catch (NotSuccessException ex) {
+            System.out.println(ex.getJobResult().getStatus() + ": " + ex.getJobResult().getResult());
+        }
+    }
+
+    @Test
+    public void testDeleteProject() {
+        String name = "projectToBeDeleted";
+        createProject(name, null, null, null);
+
+        DeleteProjectRequest request = client.deleteProject(REPOSITORY, name);
+        assertThat(request.getRepositoryName()).isEqualTo(REPOSITORY);
+        assertThat(request.getProjectName()).isEqualTo(name);
+
+        ProjectResponse project = getProjectByName(name);
+        assertThat(project).isNull();
+    }
+
+    @Test
+    public void testGetProjects() {
+        String name = "oneOfManyProjects";
+        createProject(name, null, null, null);
+
+        Collection<ProjectResponse> projects = client.getProjects(REPOSITORY);
+        assertThat(projects).extracting(ProjectResponse::getName).contains(name);
+    }
+
+    @Test
+    public void testCompileProject() {
+        String name = "projectToBeCompiled";
+        createProject(name, null, null, null);
+
+        CompileProjectRequest request = client.compileProject(REPOSITORY, name);
+        assertThat(request.getRepositoryName()).isEqualTo(REPOSITORY);
+        assertThat(request.getProjectName()).isEqualTo(name);
+    }
+
+    @Test
+    public void testTestProject() {
+        String name = "projectToBeTested";
+        createProject(name, null, null, null);
+
+        TestProjectRequest request = client.testProject(REPOSITORY, name);
+        assertThat(request.getRepositoryName()).isEqualTo(REPOSITORY);
+        assertThat(request.getProjectName()).isEqualTo(name);
+    }
+
+    @Test
+    public void testInstallProject() {
+        String name = "projectToBeInstalled" + Math.random();
+        createProject(name, null, null, null);
+
+        InstallProjectRequest request = client.installProject(REPOSITORY, name);
+        assertThat(request.getRepositoryName()).isEqualTo(REPOSITORY);
+        assertThat(request.getProjectName()).isEqualTo(name);
+    }
+
+    @Test
+    public void testInstallProjectTwice() {
+        String name = "projectToBeInstalledTwice" + Math.random();
+        createProject(name, null, null, VERSION);
+
+        InstallProjectRequest request = client.installProject(REPOSITORY, name);
+        assertThat(request.getRepositoryName()).isEqualTo(REPOSITORY);
+        assertThat(request.getProjectName()).isEqualTo(name);
+
+        try {
+            client.installProject(REPOSITORY, name);
+        } catch (NotSuccessException ex) {
+            Assertions.assertThat(ex.getJobResult().getStatus()).isEqualTo(JobStatus.DUPLICATE_RESOURCE);
+        }
+    }
+
+    @Test
+    public void testInstallProjectSnapshotTwice() {
+        String name = "projectSnapshotToBeInstalledTwice" + Math.random();
+        createProject(name, null, null, SNAPSHOT_VERSION);
+
+        InstallProjectRequest request = client.installProject(REPOSITORY, name);
+        assertThat(request.getRepositoryName()).isEqualTo(REPOSITORY);
+        assertThat(request.getProjectName()).isEqualTo(name);
+
+        request = client.installProject(REPOSITORY, name);
+        assertThat(request.getRepositoryName()).isEqualTo(REPOSITORY);
+        assertThat(request.getProjectName()).isEqualTo(name);
+    }
+
+    @Test
+    public void testDeployProject() {
+        String name = "projectToBeDeployed" + Math.random();
+        createProject(name, null, null, null);
+
+        DeployProjectRequest request = client.deployProject(REPOSITORY, name);
+        assertThat(request.getRepositoryName()).isEqualTo(REPOSITORY);
+        assertThat(request.getProjectName()).isEqualTo(name);
+    }
+
+    @Test
+    public void testDeployProjectTwice() {
+        String name = "projectToBeDeployedTwice" + Math.random();
+        createProject(name, null, null, VERSION);
+
+        DeployProjectRequest request = client.deployProject(REPOSITORY, name);
+        assertThat(request.getRepositoryName()).isEqualTo(REPOSITORY);
+        assertThat(request.getProjectName()).isEqualTo(name);
+
+        try {
+            client.deployProject(REPOSITORY, name);
+        } catch (NotSuccessException ex) {
+            Assertions.assertThat(ex.getJobResult().getStatus()).isEqualTo(JobStatus.DUPLICATE_RESOURCE);
+        }
+    }
+
+    @Test
+    public void testDeployProjectSnapshotTwice() {
+        String name = "projectSnapshotToBeDeployedTwice" + Math.random();
+        createProject(name, null, null, SNAPSHOT_VERSION);
+
+        DeployProjectRequest request = client.deployProject(REPOSITORY, name);
+        assertThat(request.getRepositoryName()).isEqualTo(REPOSITORY);
+        assertThat(request.getProjectName()).isEqualTo(name);
+
+        request = client.deployProject(REPOSITORY, name);
+        assertThat(request.getRepositoryName()).isEqualTo(REPOSITORY);
+        assertThat(request.getProjectName()).isEqualTo(name);
+    }
+
+    private void createProject(String name, String description, String groupId, String version) {
+        ProjectRequest project = new ProjectRequest();
+        project.setName(name);
+        project.setDescription(description);
+        project.setGroupId(groupId);
+        project.setVersion(version);
+
+        CreateProjectRequest request = client.createProject(REPOSITORY, project);
+        assertCreateProjectRequest(request, project);
+        assertProjectExists(project);
+    }
+
+    private void assertCreateProjectRequest(CreateProjectRequest actual, ProjectRequest expected) {
+        SoftAssertions assertions = new SoftAssertions();
+        assertions.assertThat(actual.getRepositoryName()).isEqualTo(REPOSITORY);
+        assertions.assertThat(actual.getProjectName()).isEqualTo(expected.getName());
+        assertions.assertThat(actual.getDescription()).isEqualTo(expected.getDescription());
+        assertions.assertThat(actual.getProjectGroupId()).isEqualTo(expected.getGroupId());
+        assertions.assertThat(actual.getProjectVersion()).isEqualTo(expected.getVersion());
+        assertions.assertAll();
+    }
+
+    private void assertProjectExists(ProjectRequest projectRequest) {
+        ProjectResponse projectResponse = getProjectByName(projectRequest.getName());
+
+        SoftAssertions assertions = new SoftAssertions();
+        assertions.assertThat(projectResponse.getName()).isEqualTo(projectRequest.getName());
+        assertions.assertThat(projectResponse.getDescription()).isEqualTo(projectRequest.getDescription());
+        assertions.assertThat(projectResponse.getGroupId())
+                .isEqualTo(projectRequest.getGroupId() == null ? projectRequest.getName() : projectRequest.getGroupId());
+        assertions.assertThat(projectResponse.getVersion())
+                .isEqualTo(projectRequest.getVersion() == null ? DEFAULT_VERSION : projectRequest.getVersion());
+        assertions.assertAll();
+    }
+
+    private ProjectResponse getProjectByName(String name) {
+        Collection<ProjectResponse> projects = client.getProjects(REPOSITORY);
+        return projects.parallelStream()
+                .filter(projectResponse -> projectResponse.getName().equals(name))
+                .findAny().orElse(null);
+    }
+
+}

--- a/kie-wb-tests/kie-wb-tests-rest/src/test/java/org/kie/wb/test/rest/functional/RepositoryIntegrationTest.java
+++ b/kie-wb-tests/kie-wb-tests-rest/src/test/java/org/kie/wb/test/rest/functional/RepositoryIntegrationTest.java
@@ -1,0 +1,276 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.wb.test.rest.functional;
+
+import java.util.Collection;
+
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.SoftAssertions;
+import org.guvnor.rest.client.CreateOrCloneRepositoryRequest;
+import org.guvnor.rest.client.JobStatus;
+import org.guvnor.rest.client.OrganizationalUnit;
+import org.guvnor.rest.client.RepositoryRequest;
+import org.guvnor.rest.client.RepositoryResponse;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.kie.wb.test.rest.RestTestBase;
+import org.kie.wb.test.rest.client.NotSuccessException;
+import org.kie.wb.test.rest.exception.BadRequestException;
+import org.kie.wb.test.rest.exception.NotFoundException;
+import qa.tools.ikeeper.annotation.Jira;
+
+import static org.assertj.core.api.Assertions.*;
+
+public class RepositoryIntegrationTest extends RestTestBase {
+
+    private static final String ORG_UNIT = "repoTestOrgUnit";
+    private static final String GIT_URL_REMOTE = "https://github.com/droolsjbpm/jbpm-playground.git";
+
+    @BeforeClass
+    public static void createOrganizationalUnit() {
+        OrganizationalUnit orgUnit = new OrganizationalUnit();
+        orgUnit.setName(ORG_UNIT);
+        orgUnit.setOwner(USER_ID);
+
+        client.createOrganizationalUnit(orgUnit);
+
+        deleteAllRepositories();
+    }
+
+    @AfterClass
+    public static void deleteOrganizationalUnit() {
+        deleteAllRepositories();
+
+        client.deleteOrganizationalUnit(ORG_UNIT);
+    }
+
+    @Test
+    public void testCreateRepositoryEmptyName() {
+        RepositoryRequest repository = new RepositoryRequest();
+        repository.setOrganizationalUnitName(ORG_UNIT);
+        repository.setRequestType("new");
+
+        try {
+            client.createOrCloneRepository(repository);
+            Assertions.fail("Operation should fail because of missing repository name");
+        } catch (NotSuccessException ex) {
+            assertThat(ex.getJobResult().getStatus()).isEqualTo(JobStatus.BAD_REQUEST);
+            assertThat(ex.getJobResult().getResult()).contains("name");
+        }
+    }
+
+    @Jira("GUVNOR-2542")
+    @Test(expected = BadRequestException.class)
+    public void testCreateRepositoryEmptyOrganizationalUnit() {
+        RepositoryRequest repository = new RepositoryRequest();
+        repository.setName("emptyOrgUnitRepo");
+        repository.setRequestType("new");
+
+        client.createOrCloneRepository(repository);
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void testCreateRepositoryEmptyRequestType() {
+        RepositoryRequest repository = new RepositoryRequest();
+        repository.setName("emptyRequestTypeRepo");
+        repository.setOrganizationalUnitName(ORG_UNIT);
+
+        client.createOrCloneRepository(repository);
+    }
+
+    private void testCreateOrCloneRepository(RepositoryRequest repository) {
+        CreateOrCloneRepositoryRequest request = client.createOrCloneRepository(repository);
+        assertThat(request).isNotNull();
+        assertRepositoryRequest(request.getRepository(), repository);
+
+        RepositoryResponse response = client.getRepository(repository.getName());
+        assertRepositoryResponse(response, repository);
+    }
+
+    @Test
+    public void testCreateRepositoryMinimal() {
+        RepositoryRequest repository = new RepositoryRequest();
+        repository.setName("minimalRepo");
+        repository.setOrganizationalUnitName(ORG_UNIT);
+        repository.setRequestType("new");
+
+        testCreateOrCloneRepository(repository);
+    }
+
+    @Test
+    @Jira("GUVNOR-2542")
+    public void testCreateRepositoryWithDescription() {
+        RepositoryRequest repository = new RepositoryRequest();
+        repository.setName("repoWithDescription");
+        repository.setOrganizationalUnitName(ORG_UNIT);
+        repository.setRequestType("new");
+        repository.setDescription("Some kind of description");
+
+        testCreateOrCloneRepository(repository);
+    }
+
+    @Test
+    public void testCreateRepositoryWithGitUrl() {
+        RepositoryRequest repository = new RepositoryRequest();
+        repository.setName("createdRepoWithGitUrl");
+        repository.setOrganizationalUnitName(ORG_UNIT);
+        repository.setRequestType("new");
+        repository.setGitURL(GIT_URL_REMOTE);
+
+        testCreateOrCloneRepository(repository);
+    }
+
+    @Test
+    @Jira("GUVNOR-2542")
+    public void testCloneRepositoryEmptyUrl() {
+        RepositoryRequest repository = new RepositoryRequest();
+        repository.setName("clonedRepoWithEmptyUrl");
+        repository.setOrganizationalUnitName(ORG_UNIT);
+        repository.setRequestType("clone");
+
+        try {
+            client.createOrCloneRepository(repository);
+            Assertions.fail("Operation should fail because of missing Git URL");
+        } catch (NotSuccessException ex) {
+            assertThat(ex.getJobResult().getStatus()).isEqualTo(JobStatus.BAD_REQUEST);
+        }
+    }
+
+    @Test
+    @Jira("GUVNOR-2542")
+    public void testCloneRepositoryNotExistingUrl() {
+        RepositoryRequest repository = new RepositoryRequest();
+        repository.setName("clonedRepoWithNotExistingUrl");
+        repository.setOrganizationalUnitName(ORG_UNIT);
+        repository.setRequestType("clone");
+        repository.setGitURL(GIT_URL_REMOTE + "xyz");
+
+        try {
+            client.createOrCloneRepository(repository);
+            Assertions.fail("Operation should fail because of not valid Git URL");
+        } catch (NotSuccessException ex) {
+            assertThat(ex.getJobResult().getStatus()).isEqualTo(JobStatus.BAD_REQUEST);
+        }
+    }
+
+    @Test
+    public void testCloneRepositoryRemote() {
+        RepositoryRequest repository = new RepositoryRequest();
+        repository.setName("clonedRemoteRepo");
+        repository.setOrganizationalUnitName(ORG_UNIT);
+        repository.setRequestType("clone");
+        repository.setGitURL(GIT_URL_REMOTE);
+
+        testCreateOrCloneRepository(repository);
+    }
+
+    private RepositoryRequest prepareRepository(String name) {
+        RepositoryRequest repository = new RepositoryRequest();
+        repository.setName(name);
+        repository.setOrganizationalUnitName(ORG_UNIT);
+        repository.setRequestType("new");
+
+        return client.createOrCloneRepository(repository).getRepository();
+    }
+
+    @Test
+    public void testCloneRepositoryInternal() {
+        String originalRepo = "repoToBeCloned";
+        prepareRepository(originalRepo);
+
+        RepositoryRequest repository = new RepositoryRequest();
+        repository.setName("clonedInternalRepo");
+        repository.setOrganizationalUnitName(ORG_UNIT);
+        repository.setRequestType("clone");
+        repository.setGitURL("git://localhost:9418/" + originalRepo);
+
+        testCreateOrCloneRepository(repository);
+    }
+
+    @Test
+    public void testDeleteRepository() {
+        String name = "repoToBeDeleted";
+        prepareRepository(name);
+
+        client.deleteRepository(name);
+
+        try {
+            client.getRepository(name);
+            Assertions.fail("Repository should have been deleted");
+        } catch (NotFoundException ex) {
+            // expected, repository has been deleted
+        }
+    }
+
+    @Jira("GUVNOR-2542")
+    @Test(expected = NotFoundException.class)
+    public void testDeleteRepositoryNotExisting() {
+        client.deleteRepository("notExistingRepo");
+    }
+
+    @Test
+    public void testGetExistingRepository() {
+        String name = "getExistingRepo";
+        prepareRepository(name);
+
+        RepositoryResponse repository = client.getRepository(name);
+        assertThat(repository.getName()).isEqualTo(name);
+    }
+
+    @Test(expected = NotFoundException.class)
+    public void testGetNotExistingRepository() {
+        client.getRepository("notExistingRepo");
+    }
+
+    @Test
+    public void testGetRepositories() {
+        String name = "oneOfManyRepos";
+        prepareRepository(name);
+
+        Collection<RepositoryResponse> repositories = client.getRepositories();
+        assertThat(repositories).extracting(RepositoryResponse::getName).contains(name);
+    }
+
+    private void assertRepositoryRequest(RepositoryRequest actual, RepositoryRequest expected) {
+        assertThat(actual).isNotNull();
+
+        SoftAssertions assertions = new SoftAssertions();
+        assertions.assertThat(actual.getName()).isEqualTo(expected.getName());
+        assertions.assertThat(actual.getDescription()).isEqualTo(expected.getDescription());
+        assertions.assertThat(actual.getOrganizationalUnitName())
+                .isEqualTo(expected.getOrganizationalUnitName());
+        assertions.assertThat(actual.getUserName()).isEqualTo(expected.getUserName());
+        assertions.assertThat(actual.getPassword()).isEqualTo(expected.getPassword());
+        assertions.assertThat(actual.getRequestType()).isEqualTo(expected.getRequestType());
+        assertions.assertThat(actual.getGitURL()).isEqualTo(expected.getGitURL());
+        assertions.assertAll();
+    }
+
+    private void assertRepositoryResponse(RepositoryResponse actual, RepositoryRequest expected) {
+        assertThat(actual).isNotNull();
+
+        SoftAssertions assertions = new SoftAssertions();
+        assertions.assertThat(actual.getName()).isEqualTo(expected.getName());
+        assertions.assertThat(actual.getDescription()).isEqualTo(expected.getDescription());
+        assertions.assertThat(actual.getUserName()).isEqualTo(expected.getUserName());
+        assertions.assertThat(actual.getPassword()).isEqualTo(expected.getPassword());
+        assertions.assertThat(actual.getRequestType()).isNull();
+        assertions.assertAll();
+    }
+
+}

--- a/kie-wb-tests/pom.xml
+++ b/kie-wb-tests/pom.xml
@@ -1,0 +1,279 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>kie-wb-distributions</artifactId>
+    <groupId>org.kie</groupId>
+    <version>7.0.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>kie-wb-tests</artifactId>
+  <packaging>pom</packaging>
+
+  <name>KIE (Drools) Workbench Tests :: Parent</name>
+  <description>Parent for integration tests for KIE Workbench and KIE Drools Workbench</description>
+
+  <modules>
+    <module>kie-wb-tests-rest</module>
+  </modules>
+
+  <properties>
+    <deployable.classifier.tomcat8>tomcat7</deployable.classifier.tomcat8>
+    <deployable.classifier.wildfly10>wildfly10</deployable.classifier.wildfly10>
+    <deployable.context>kie-wb</deployable.context>
+
+    <deployable.groupId>org.kie</deployable.groupId>
+    <deployable.artifactId>kie-wb-distribution-wars</deployable.artifactId>
+    <deployable.version>${version.org.kie}</deployable.version>
+
+    <deployment.timeout>90000</deployment.timeout>
+
+    <container.host>localhost</container.host>
+    <container.port>8080</container.port>
+    <kie.wb.url>http://${container.host}:${container.port}/${deployable.context}</kie.wb.url>
+
+    <version.tomcat8>8.0.36</version.tomcat8>
+    <version.wildfly10>10.0.0.Final</version.wildfly10>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.kie</groupId>
+        <artifactId>kie-wb-tests-rest</artifactId>
+        <version>${version.org.kie}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>link.bek.tools</groupId>
+      <artifactId>issue-keeper-junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.codehaus.cargo</groupId>
+          <artifactId>cargo-maven2-plugin</artifactId>
+          <configuration>
+            <container>
+              <containerId>${cargo.container.id}</containerId>
+              <systemProperties>
+                <kie.maven.settings.custom>${project.build.testOutputDirectory}/settings.xml</kie.maven.settings.custom>
+                <!-- Fixes issue when Tomcat hangs during deployment due to insufficient amount of entropy.
+                     The property specifies less secure source of entropy, which is fine for testing.
+                     See https://wiki.apache.org/tomcat/HowTo/FasterStartUp#Entropy_Source for more info -->
+                <java.security.egd>file:/dev/./urandom</java.security.egd>
+              </systemProperties>
+            </container>
+            <deployables>
+              <deployable>
+                <groupId>${deployable.groupId}</groupId>
+                <artifactId>${deployable.artifactId}</artifactId>
+                <!-- default, may be overridden in container specific profiles -->
+                <classifier>${deployable.classifier}</classifier>
+                <type>war</type>
+                <properties>
+                  <context>${deployable.context}</context>
+                </properties>
+                <pingURL>${kie.wb.url}</pingURL>
+                <pingTimeout>${deployment.timeout}</pingTimeout>
+              </deployable>
+            </deployables>
+            <configuration>
+              <properties>
+                <cargo.servlet.port>${container.port}</cargo.servlet.port>
+                <cargo.servlet.users>
+                  restAll:restAll1234;:admin,rest-all|restProject:restProject1234;:admin,rest-project|noRest:noRest1234;:admin
+                </cargo.servlet.users>
+              </properties>
+            </configuration>
+          </configuration>
+          <executions>
+            <execution>
+              <id>start-container</id>
+              <phase>pre-integration-test</phase>
+              <goals>
+                <goal>start</goal>
+              </goals>
+            </execution>
+            <execution>
+              <id>stop-container</id>
+              <phase>post-integration-test</phase>
+              <goals>
+                <goal>stop</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-failsafe-plugin</artifactId>
+          <configuration>
+            <systemPropertyVariables>
+              <kie.wb.url>${kie.wb.url}</kie.wb.url>
+            </systemPropertyVariables>
+            <failIfNoTests>false</failIfNoTests>
+            <argLine>-Xmx1024m -Dfile.encoding=UTF-8</argLine>
+          </configuration>
+          <executions>
+            <execution>
+              <goals>
+                <goal>integration-test</goal>
+                <goal>verify</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>build-helper-maven-plugin</artifactId>
+          <executions>
+            <execution>
+              <id>reserve-network-port</id>
+              <goals>
+                <goal>reserve-network-port</goal>
+              </goals>
+              <phase>pre-integration-test</phase>
+              <configuration>
+                <portNames>
+                  <portName>container.port</portName>
+                </portNames>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
+  <profiles>
+    <profile>
+      <id>kie-drools-wb</id>
+      <properties>
+        <deployable.groupId>org.kie</deployable.groupId>
+        <deployable.artifactId>kie-drools-wb-distribution-wars</deployable.artifactId>
+        <deployable.context>kie-drools-wb</deployable.context>
+      </properties>
+    </profile>
+
+    <profile>
+      <id>kie-wb</id>
+      <properties>
+        <deployable.groupId>org.kie</deployable.groupId>
+        <deployable.artifactId>kie-wb-distribution-wars</deployable.artifactId>
+        <deployable.context>kie-wb</deployable.context>
+      </properties>
+    </profile>
+
+    <profile>
+      <id>wildfly10</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.kie</groupId>
+          <artifactId>kie-wb-distribution-wars</artifactId>
+          <classifier>${deployable.classifier.wildfly10}</classifier>
+          <type>war</type>
+        </dependency>
+        <dependency>
+          <groupId>org.kie</groupId>
+          <artifactId>kie-drools-wb-distribution-wars</artifactId>
+          <classifier>${deployable.classifier.wildfly10}</classifier>
+          <type>war</type>
+        </dependency>
+      </dependencies>
+      <properties>
+        <cargo.container.id>wildfly10x</cargo.container.id>
+      </properties>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.codehaus.cargo</groupId>
+              <artifactId>cargo-maven2-plugin</artifactId>
+              <configuration>
+                <container>
+                  <type>installed</type>
+                  <artifactInstaller>
+                    <groupId>org.wildfly</groupId>
+                    <artifactId>wildfly-dist</artifactId>
+                    <version>${version.wildfly10}</version>
+                  </artifactInstaller>
+                </container>
+                <configuration>
+                  <properties>
+                    <cargo.jboss.configuration>standalone-full</cargo.jboss.configuration>
+                    <cargo.jvmargs>-Xmx1024m</cargo.jvmargs>
+                  </properties>
+                </configuration>
+                <deployables>
+                  <deployable>
+                    <groupId>${deployable.groupId}</groupId>
+                    <artifactId>${deployable.artifactId}</artifactId>
+                    <classifier>${deployable.classifier.wildfly10}</classifier>
+                    <type>war</type>
+                  </deployable>
+                </deployables>
+              </configuration>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+      </build>
+    </profile>
+
+    <!-- Tests are disabled by default. They can be run using the specific profiles. -->
+    <profile>
+      <id>disable-cargo-and-tests</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.cargo</groupId>
+            <artifactId>cargo-maven2-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>start-container</id>
+                <phase>none</phase>
+                <!-- do nothing, container is not managed by Cargo! -->
+                <goals/>
+              </execution>
+              <execution>
+                <id>stop-container</id>
+                <phase>none</phase>
+                <!-- do nothing, container is not managed by Cargo! -->
+                <goals/>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <configuration>
+              <skipITs>true</skipITs>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,7 @@
     <module>kie-drools-wb</module>
     <module>kie-tomcat-integration</module>
     <module>kie-wb-smoke-tests</module>
+    <module>kie-wb-tests</module>
   </modules>
 
   <build>


### PR DESCRIPTION
I have taken KIE Workbench REST tests from QE test suite and added many new test cases. Right now, the only container where they can run is Wildfly 8. I have not added support for other containers since it does not make sense for 7.x. Cargo is used to configure and start this container now but it will be replaced as we change KIE Workbench to be able to run independently.

These tests have discovered many potential problems. All of them are described in [GUVNOR-2542](https://issues.jboss.org/browse/GUVNOR-2542) where we can discuss if they really need to be fixed. The reproducers have Jira annotations so you can easily find them in the code. Just comment out this annotation to see the actual behavior since those tests are ignored unless [GUVNOR-2542](https://issues.jboss.org/browse/GUVNOR-2542) is resolved.