### PR TITLE
Exclude errai-cdi-server from EAP 6.4 WARs

### DIFF
--- a/kie-drools-wb/kie-drools-wb-distribution-wars/src/main/assembly/component-kie-drools-wb-eap-6_4-common.xml
+++ b/kie-drools-wb/kie-drools-wb-distribution-wars/src/main/assembly/component-kie-drools-wb-eap-6_4-common.xml
@@ -25,7 +25,7 @@
 
           <exclude>WEB-INF/classes/org/kie/workbench/backend/weblogic/</exclude>
           <!-- Errai 1.1+ CDI Compat -->
-          <exclude>WEB-INF/lib/errai-weld-integration-*.jar</exclude>
+          <exclude>WEB-INF/lib/errai-cdi-server-*.jar</exclude>
 
           <!-- Exclude the default security management settings and provide a custom ones for this distro, if any. -->
           <exclude>WEB-INF/classes/security-management.properties</exclude>

--- a/kie-wb/kie-wb-distribution-wars/src/main/assembly/component-kie-wb-eap-6_4-common.xml
+++ b/kie-wb/kie-wb-distribution-wars/src/main/assembly/component-kie-wb-eap-6_4-common.xml
@@ -25,7 +25,7 @@
 
             <exclude>WEB-INF/classes/org/kie/workbench/backend/weblogic/</exclude>
             <!-- Errai 1.1+ CDI Compat -->
-            <exclude>WEB-INF/lib/errai-weld-integration-*.jar</exclude>
+            <exclude>WEB-INF/lib/errai-cdi-server-*.jar</exclude>
             
             <!-- Exclude the default security management settings and provide a custom ones for this distro. -->
             <exclude>WEB-INF/classes/security-management.properties</exclude>


### PR DESCRIPTION
This is a trivial fix to make the WARs working on EAP 6.4 until we move to WFLY10/EAP7.