### PR TITLE
[6.5.x] fix uf-security-wildfly exclusions in assembly files

### DIFF
--- a/kie-drools-wb/kie-drools-wb-distribution-wars/src/main/assembly/component-kie-drools-wb-tomcat-7-common.xml
+++ b/kie-drools-wb/kie-drools-wb-distribution-wars/src/main/assembly/component-kie-drools-wb-tomcat-7-common.xml
@@ -101,7 +101,7 @@
           <exclude>WEB-INF/lib/errai-weld-integration-*.jar</exclude>
           
           <!-- Exclude the UF Security management provider for Wildfly, the default one in the workbench, and provide the one for this distro, if any.-->
-          <exclude>WEB-INF/lib/uberfire-security-management-wildfly-*.jar</exclude>
+          <exclude>WEB-INF/lib/uberfire-security-management-wildfly*.jar</exclude>
           <!-- Exclude the default security management settings and provide a custom ones for this distro, if any. -->
           <exclude>WEB-INF/classes/security-management.properties</exclude>
 

--- a/kie-drools-wb/kie-drools-wb-distribution-wars/src/main/assembly/component-kie-drools-wb-weblogic-12-common.xml
+++ b/kie-drools-wb/kie-drools-wb-distribution-wars/src/main/assembly/component-kie-drools-wb-weblogic-12-common.xml
@@ -73,7 +73,7 @@
           <exclude>WEB-INF/lib/jgroups-*.jar</exclude>
 
           <!-- Exclude the UF Security management provider for Wildfly, the default one in the workbench, and provide the one for this distro, if any.-->
-          <exclude>WEB-INF/lib/uberfire-security-management-wildfly-*.jar</exclude>
+          <exclude>WEB-INF/lib/uberfire-security-management-wildfly*.jar</exclude>
           <!-- Exclude the default security management settings and provide a custom ones for this distro, if any. -->
           <exclude>WEB-INF/classes/security-management.properties</exclude>
           

--- a/kie-drools-wb/kie-drools-wb-distribution-wars/src/main/assembly/component-kie-drools-wb-websphere-as-8-common.xml
+++ b/kie-drools-wb/kie-drools-wb-distribution-wars/src/main/assembly/component-kie-drools-wb-websphere-as-8-common.xml
@@ -76,7 +76,7 @@
           <exclude>WEB-INF/lib/jgroups-*.jar</exclude>
 
           <!-- Exclude the UF Security management provider for Wildfly, the default one in the workbench, and provide the one for this distro, if any.-->
-          <exclude>WEB-INF/lib/uberfire-security-management-wildfly-*.jar</exclude>
+          <exclude>WEB-INF/lib/uberfire-security-management-wildfly*.jar</exclude>
           <!-- Exclude the default security management settings and provide a custom ones for this distro, if any. -->
           <exclude>WEB-INF/classes/security-management.properties</exclude>
 

--- a/kie-wb/kie-wb-distribution-wars/src/main/assembly/component-kie-wb-tomcat-7-common.xml
+++ b/kie-wb/kie-wb-distribution-wars/src/main/assembly/component-kie-wb-tomcat-7-common.xml
@@ -100,7 +100,7 @@
             <exclude>WEB-INF/lib/errai-weld-integration-*.jar</exclude>
             
             <!-- Exclude the UF Security management provider for Wildfly, the default one in the workbench, and provide the one for this distro.-->
-            <exclude>WEB-INF/lib/uberfire-security-management-wildfly-*.jar</exclude>
+            <exclude>WEB-INF/lib/uberfire-security-management-wildfly*.jar</exclude>
             <!-- Exclude the default security management settings and provide a custom ones for this distro. -->
             <exclude>WEB-INF/classes/security-management.properties</exclude>
             

--- a/kie-wb/kie-wb-distribution-wars/src/main/assembly/component-kie-wb-weblogic-12-common.xml
+++ b/kie-wb/kie-wb-distribution-wars/src/main/assembly/component-kie-wb-weblogic-12-common.xml
@@ -74,7 +74,7 @@
             <exclude>WEB-INF/lib/jgroups-*.jar</exclude>
 
             <!-- Exclude the UF Security management provider for Wildfly, the default one in the workbench, and provide the one for this distro, if any.-->
-            <exclude>WEB-INF/lib/uberfire-security-management-wildfly-*.jar</exclude>
+            <exclude>WEB-INF/lib/uberfire-security-management-wildfly*.jar</exclude>
             <!-- Exclude the default security management settings and provide a custom ones for this distro, if any. -->
             <exclude>WEB-INF/classes/security-management.properties</exclude>
             

--- a/kie-wb/kie-wb-distribution-wars/src/main/assembly/component-kie-wb-websphere-as-8-common.xml
+++ b/kie-wb/kie-wb-distribution-wars/src/main/assembly/component-kie-wb-websphere-as-8-common.xml
@@ -78,7 +78,7 @@
            <exclude>WEB-INF/lib/jgroups-*.jar</exclude>
 
            <!-- Exclude the UF Security management provider for Wildfly, the default one in the workbench, and provide the one for this distro, if any.-->
-           <exclude>WEB-INF/lib/uberfire-security-management-wildfly-*.jar</exclude>
+           <exclude>WEB-INF/lib/uberfire-security-management-wildfly*.jar</exclude>
            <!-- Exclude the default security management settings and provide a custom ones for this distro, if any. -->
            <exclude>WEB-INF/classes/security-management.properties</exclude>
            


### PR DESCRIPTION
 * as part of EAP7 WARs work, the uf-ext modules were renamed
   from *-wildfly-<version> to *-wildlfy8-<version> and the
   exclusion thus did not match those modules which caused issues
   mainly on WebLogic