### PR TITLE
GUVNOR-2647: proper error handling on logout.jsp, needed when JSM is enabled on EAP

### DIFF
--- a/kie-drools-wb/kie-drools-wb-distribution-wars/src/main/productized/webapp/logout.jsp
+++ b/kie-drools-wb/kie-drools-wb-distribution-wars/src/main/productized/webapp/logout.jsp
@@ -1,14 +1,22 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8"
          pageEncoding="UTF-8" %>
 <%@ page import="java.util.Locale" %>
+<%@ page import="org.slf4j.Logger" %>
+<%@ page import="org.slf4j.LoggerFactory" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://jakarta.apache.org/taglibs/i18n-1.0" prefix="i18n" %>
 <%
-  request.logout();
-  javax.servlet.http.HttpSession httpSession = request.getSession(false);
-  if (httpSession != null) {
-    httpSession.invalidate();
+  final Logger logger = LoggerFactory.getLogger( "logout.jsp" );
+  try {
+    request.logout();
+    javax.servlet.http.HttpSession httpSession = request.getSession(false);
+    if (httpSession != null) {
+      httpSession.invalidate();
+    }
+  } catch ( SecurityException e ) {
+    //The only case we know that this  happens is when java security manager is enabled on EAP.
+    logger.debug( "Security exception happened, without consequences, during logout.", e );
   }
   Locale locale = null;
   try {

--- a/kie-drools-wb/kie-drools-wb-webapp/src/main/webapp/logout.jsp
+++ b/kie-drools-wb/kie-drools-wb-webapp/src/main/webapp/logout.jsp
@@ -1,14 +1,22 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8"
          pageEncoding="UTF-8" %>
 <%@ page import="java.util.Locale" %>
+<%@ page import="org.slf4j.Logger" %>
+<%@ page import="org.slf4j.LoggerFactory" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://jakarta.apache.org/taglibs/i18n-1.0" prefix="i18n" %>
 <%
-  request.logout();
-  javax.servlet.http.HttpSession httpSession = request.getSession(false);
-  if (httpSession != null) {
-    httpSession.invalidate();
+  final Logger logger = LoggerFactory.getLogger( "logout.jsp" );
+  try {
+    request.logout();
+    javax.servlet.http.HttpSession httpSession = request.getSession(false);
+    if (httpSession != null) {
+      httpSession.invalidate();
+    }
+  } catch ( SecurityException e ) {
+    //The only case we know that this  happens is when java security manager is enabled on EAP.
+    logger.debug( "Security exception happened, without consequences, during logout.", e );
   }
   Locale locale = null;
   try {

--- a/kie-wb/kie-wb-distribution-wars/src/main/productized/webapp/logout.jsp
+++ b/kie-wb/kie-wb-distribution-wars/src/main/productized/webapp/logout.jsp
@@ -1,14 +1,22 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8"
          pageEncoding="UTF-8" %>
 <%@ page import="java.util.Locale" %>
+<%@ page import="org.slf4j.Logger" %>
+<%@ page import="org.slf4j.LoggerFactory" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://jakarta.apache.org/taglibs/i18n-1.0" prefix="i18n" %>
 <%
-  request.logout();
-  javax.servlet.http.HttpSession httpSession = request.getSession(false);
-  if (httpSession != null) {
-    httpSession.invalidate();
+  final Logger logger = LoggerFactory.getLogger( "logout.jsp" );
+  try {
+    request.logout();
+    javax.servlet.http.HttpSession httpSession = request.getSession(false);
+    if (httpSession != null) {
+      httpSession.invalidate();
+    }
+  } catch ( SecurityException e ) {
+    //The only case we know that this  happens is when java security manager is enabled on EAP.
+    logger.debug( "Security exception happened, without consequences, during logout.", e );
   }
   Locale locale = null;
   try {

--- a/kie-wb/kie-wb-webapp/src/main/webapp/logout.jsp
+++ b/kie-wb/kie-wb-webapp/src/main/webapp/logout.jsp
@@ -1,14 +1,22 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8"
          pageEncoding="UTF-8" %>
 <%@ page import="java.util.Locale" %>
+<%@ page import="org.slf4j.Logger" %>
+<%@ page import="org.slf4j.LoggerFactory" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://jakarta.apache.org/taglibs/i18n-1.0" prefix="i18n" %>
 <%
-  request.logout();
-  javax.servlet.http.HttpSession httpSession = request.getSession(false);
-  if (httpSession != null) {
-    httpSession.invalidate();
+  final Logger logger = LoggerFactory.getLogger( "logout.jsp" );
+  try {
+    request.logout();
+    javax.servlet.http.HttpSession httpSession = request.getSession(false);
+    if (httpSession != null) {
+      httpSession.invalidate();
+    }
+  } catch ( SecurityException e ) {
+    //The only case we know that this  happens is when java security manager is enabled on EAP.
+    logger.debug( "Security exception happened, without consequences, during logout.", e );
   }
   Locale locale = null;
   try {


### PR DESCRIPTION
as discussed with @mswiderski; the less risk operation is just add a try catch, so avoid problems on different containers.