### PR TITLE
RHBPMS-4145: Language selection is not remembered on relogin in Chrome

### DIFF
--- a/kie-drools-wb/kie-drools-wb-distribution-wars/src/main/productized/webapp/login.jsp
+++ b/kie-drools-wb/kie-drools-wb-distribution-wars/src/main/productized/webapp/login.jsp
@@ -41,7 +41,7 @@
                         <strong><i18n:message key="loginFailed">Login failed: Not Authorized</i18n:message></strong>
                     </div>
                 </c:if>
-                <form class="form-horizontal" role="form" action="j_security_check" method="POST">
+                <form class="form-horizontal" role="form" action="j_security_check?locale=<%=locale%>" method="POST">
                     <div class="form-group">
                         <label for="j_username" class="col-sm-2 col-md-2 control-label"><i18n:message key="UserName">Username</i18n:message></label>
                         <div class="col-sm-10 col-md-10">

--- a/kie-drools-wb/kie-drools-wb-distribution-wars/src/main/productized/webapp/logout.jsp
+++ b/kie-drools-wb/kie-drools-wb-distribution-wars/src/main/productized/webapp/logout.jsp
@@ -52,7 +52,7 @@
                     <span class="pficon pficon-ok"></span>
                     <strong><i18n:message key="logoutSuccssful">Logout successful</i18n:message></strong>
                 </div>
-                <form class="form-horizontal" role="form" action="<%= request.getContextPath() %>" method="POST">
+                <form class="form-horizontal" role="form" action="<%= request.getContextPath() %>/kie-drools-wb.html?locale=<%=locale%>" method="POST">
                     <div class="form-group">
                         <div class="col-xs-offset-8 col-xs-4 col-sm-offset-8 col-sm-4 col-md-offset-8 col-md-4 submit">
                             <button type="submit" class="btn btn-primary btn-lg" tabindex="1"><i18n:message key="loginAgain">Login again</i18n:message></button>

--- a/kie-drools-wb/kie-drools-wb-distribution-wars/src/main/productized/webapp/not_authorized.jsp
+++ b/kie-drools-wb/kie-drools-wb-distribution-wars/src/main/productized/webapp/not_authorized.jsp
@@ -43,7 +43,7 @@
                     <span class="pficon pficon-error-circle-o"></span>
                     <strong><i18n:message key="loginFailed">Login failed: Not Authorized</i18n:message></strong>
                 </div>
-                <form class="form-horizontal" role="form" action="<%= request.getContextPath() %>/kie-drools-wb.html" method="GET">
+                <form class="form-horizontal" role="form" action="<%= request.getContextPath() %>/kie-drools-wb.html?locale=<%=locale%>" method="GET">
                     <div class="form-group">
                         <div class="col-xs-offset-8 col-xs-4 col-sm-offset-8 col-sm-4 col-md-offset-8 col-md-4 submit">
                             <button type="submit" class="btn btn-primary btn-lg" tabindex="1"><i18n:message key="loginAsAnotherUser">Login as another user</i18n:message></button>

--- a/kie-drools-wb/kie-drools-wb-webapp/src/main/webapp/login.jsp
+++ b/kie-drools-wb/kie-drools-wb-webapp/src/main/webapp/login.jsp
@@ -34,7 +34,7 @@
     </div>
 
     <div id="login-content" class="png_bg">      
-      <form action="j_security_check" method="POST">
+      <form action="j_security_check?locale=<%=locale%>" method="POST">
         <fieldset>
           <c:if test="${param.message != null}">
             <h3><i18n:message key="loginFailed">Login failed: Not Authorized</i18n:message></h3>

--- a/kie-drools-wb/kie-drools-wb-webapp/src/main/webapp/logout.jsp
+++ b/kie-drools-wb/kie-drools-wb-webapp/src/main/webapp/logout.jsp
@@ -45,7 +45,7 @@
     </div>
 
     <div id="login-content" class="png_bg">        
-      <form action="<%= request.getContextPath() %>" method="POST">
+      <form action="<%= request.getContextPath() %>/kie-drools-wb.html?locale=<%=locale%>" method="POST">
         <fieldset>
           <h3 id="logout"><i18n:message key="logoutSuccssful">Logout successful</i18n:message></h3>
           <p>

--- a/kie-drools-wb/kie-drools-wb-webapp/src/main/webapp/not_authorized.jsp
+++ b/kie-drools-wb/kie-drools-wb-webapp/src/main/webapp/not_authorized.jsp
@@ -33,7 +33,7 @@
     </div>
 
     <div id="login-content" class="png_bg">
-      <form action="<%= request.getContextPath() %>/kie-drools-wb.html" method="GET">
+      <form action="<%= request.getContextPath() %>/kie-drools-wb.html?locale=<%=locale%>" method="GET">
         <h3><i18n:message key="loginFailed">Login failed: Not Authorized</i18n:message></h3>
         <p>
           <% if (request.getParameter("gwt.codesvr") != null) { %>

--- a/kie-wb-tests/kie-wb-tests-gui/README.md
+++ b/kie-wb-tests/kie-wb-tests-gui/README.md
@@ -1,0 +1,25 @@
+#KIE Workbench tests
+
+This module contains GUI tests which require KIE Workbench to be running in order to be executed.
+
+##Running and debugging tests locally
+
+You can run tests directly from the command line.
+Cargo will take care of starting the container and the tests will be run afterwards.
+
+```
+mvn clean verify -Pkie-wb,wildfly10
+```
+
+**Note, Selenium 2.53.0 requires Firefox 46 and is incompatible with later versions.**
+
+Older versions can be downloaded from https://ftp.mozilla.org/pub/firefox/releases/46.0/ and tests ran as below:
+
+```
+mvn clean verify -Pkie-wb,wildfly10 -Dwebdriver.firefox.bin=/path/to/older/firefox/<firefox-bin>
+```
+
+For example:
+```
+mvn clean verify -Pkie-wb,wildfly10 -Dwebdriver.firefox.bin=/home/myuser/installs/ff46.0/firefox/firefox
+```

--- a/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/AbstractPerspective.java
+++ b/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/AbstractPerspective.java
@@ -26,7 +26,7 @@ public abstract class AbstractPerspective extends PageObject {
 
     @Page
     private PrimaryNavbar navbar;
-    @FindBy(css = "input[value='Login again']")
+    @FindBy(css = "input[type='submit']")
     private WebElement loginAgainButton;
 
     public PrimaryNavbar getNavbar() {

--- a/kie-wb-theme/.gitignore
+++ b/kie-wb-theme/.gitignore
@@ -1,0 +1,14 @@
+/target
+/local
+
+# Eclipse, Netbeans and IntelliJ files
+/.*
+/**/.*
+!.gitignore
+/nbproject
+*.ipr
+*.iws
+*.iml
+
+# Repository wide ignore mac DS_Store files
+.DS_Store

--- a/kie-wb-theme/kie-wb-theme-community/.gitignore
+++ b/kie-wb-theme/kie-wb-theme-community/.gitignore
@@ -1,0 +1,14 @@
+/target
+/local
+
+# Eclipse, Netbeans and IntelliJ files
+/.*
+/**/.*
+!.gitignore
+/nbproject
+*.ipr
+*.iws
+*.iml
+
+# Repository wide ignore mac DS_Store files
+.DS_Store

--- a/kie-wb-theme/kie-wb-theme-product/.gitignore
+++ b/kie-wb-theme/kie-wb-theme-product/.gitignore
@@ -1,0 +1,14 @@
+/target
+/local
+
+# Eclipse, Netbeans and IntelliJ files
+/.*
+/**/.*
+!.gitignore
+/nbproject
+*.ipr
+*.iws
+*.iml
+
+# Repository wide ignore mac DS_Store files
+.DS_Store

--- a/kie-wb/kie-wb-distribution-wars/src/main/productized/webapp/login.jsp
+++ b/kie-wb/kie-wb-distribution-wars/src/main/productized/webapp/login.jsp
@@ -42,7 +42,7 @@
                         <strong><i18n:message key="loginFailed">Login failed: Not Authorized</i18n:message></strong>
                     </div>
                 </c:if>
-                <form class="form-horizontal" role="form" action="j_security_check" method="POST">
+                <form class="form-horizontal" role="form" action="j_security_check?locale=<%=locale%>" method="POST">
                     <div class="form-group">
                         <label for="j_username" class="col-sm-2 col-md-2 control-label"><i18n:message key="UserName">Username</i18n:message></label>
                         <div class="col-sm-10 col-md-10">

--- a/kie-wb/kie-wb-distribution-wars/src/main/productized/webapp/logout.jsp
+++ b/kie-wb/kie-wb-distribution-wars/src/main/productized/webapp/logout.jsp
@@ -52,7 +52,7 @@
                     <span class="pficon pficon-ok"></span>
                     <strong><i18n:message key="logoutSuccssful">Logout successful</i18n:message></strong>
                 </div>
-                <form class="form-horizontal" role="form" action="<%= request.getContextPath() %>" method="POST">
+                <form class="form-horizontal" role="form" action="<%= request.getContextPath() %>/kie-wb.html?locale=<%=locale%>" method="POST">
                     <div class="form-group">
                         <div class="col-xs-offset-8 col-xs-4 col-sm-offset-8 col-sm-4 col-md-offset-8 col-md-4 submit">
                             <button type="submit" class="btn btn-primary btn-lg" tabindex="1"><i18n:message key="loginAgain">Login again</i18n:message></button>

--- a/kie-wb/kie-wb-distribution-wars/src/main/productized/webapp/not_authorized.jsp
+++ b/kie-wb/kie-wb-distribution-wars/src/main/productized/webapp/not_authorized.jsp
@@ -41,7 +41,7 @@
                     <span class="pficon pficon-error-circle-o"></span>
                     <strong><i18n:message key="loginFailed">Login failed: Not Authorized</i18n:message></strong>
                 </div>
-                <form class="form-horizontal" role="form" action="<%= request.getContextPath() %>/kie-wb.html" method="POST">
+                <form class="form-horizontal" role="form" action="<%= request.getContextPath() %>/kie-wb.html?locale=<%=locale%>" method="POST">
                     <div class="form-group">
                         <div class="col-xs-offset-8 col-xs-4 col-sm-offset-8 col-sm-4 col-md-offset-8 col-md-4 submit">
                             <button type="submit" class="btn btn-primary btn-lg" tabindex="1"><i18n:message key="loginAsAnotherUser">Login as another user</i18n:message></button>

--- a/kie-wb/kie-wb-webapp/src/main/webapp/login.jsp
+++ b/kie-wb/kie-wb-webapp/src/main/webapp/login.jsp
@@ -34,7 +34,7 @@
     </div>
 
     <div id="login-content" class="png_bg">      
-      <form action="j_security_check" method="POST">
+      <form action="j_security_check?locale=<%=locale%>" method="POST">
         <fieldset>
           <c:if test="${param.message != null}">
             <h3><i18n:message key="loginFailed">Login failed: Not Authorized</i18n:message></h3><br/>

--- a/kie-wb/kie-wb-webapp/src/main/webapp/logout.jsp
+++ b/kie-wb/kie-wb-webapp/src/main/webapp/logout.jsp
@@ -46,7 +46,7 @@
     </div>
 
     <div id="login-content" class="png_bg">    
-      <form action="<%= request.getContextPath() %>" method="POST">
+      <form action="<%= request.getContextPath() %>/kie-wb.html?locale=<%=locale%>" method="POST">
         <fieldset>
           <h3 id="logout"><i18n:message key="logoutSuccssful">Logout successful</i18n:message></h3>          
           <% if (request.getParameter("gwt.codesvr") != null) { %>

--- a/kie-wb/kie-wb-webapp/src/main/webapp/not_authorized.jsp
+++ b/kie-wb/kie-wb-webapp/src/main/webapp/not_authorized.jsp
@@ -34,7 +34,7 @@
     </div>
 
     <div id="login-content" class="png_bg">    
-      <form action="<%= request.getContextPath() %>/kie-wb.html" method="GET">
+      <form action="<%= request.getContextPath() %>/kie-wb.html?locale=<%=locale%>" method="GET">
         <fieldset>
           <h3><i18n:message key="loginFailed">Login failed: Not Authorized</i18n:message></h3>            
           <% if (request.getParameter("gwt.codesvr") != null) { %>


### PR DESCRIPTION
See https://issues.jboss.org/browse/RHBPMS-4145

A couple of notable changes:-

- ```login.jsp```, ```logout.jsp``` and ```not_authorized.jsp``` preserve the (Query String) "locale" parameter.
- ```logout.jsp``` correctly redirects to the login page (IIRC @karreiro found this broken too)
- ```.gitignore``` files added for ```kie-wb-theme```