### PR TITLE
[6.5.x] RHBRMS-2598: Asset search is broken

### DIFF
--- a/kie-drools-wb/kie-drools-wb-webapp/src/main/java/org/kie/workbench/drools/backend/server/LuceneConfigProducer.java
+++ b/kie-drools-wb/kie-drools-wb-webapp/src/main/java/org/kie/workbench/drools/backend/server/LuceneConfigProducer.java
@@ -39,6 +39,7 @@ import org.kie.workbench.common.services.refactoring.model.index.terms.TypeIndex
 import org.uberfire.ext.metadata.backend.lucene.LuceneConfig;
 import org.uberfire.ext.metadata.backend.lucene.LuceneConfigBuilder;
 import org.uberfire.ext.metadata.backend.lucene.analyzer.FilenameAnalyzer;
+import org.uberfire.ext.metadata.backend.lucene.index.LuceneIndex;
 
 import static org.apache.lucene.util.Version.*;
 
@@ -63,7 +64,7 @@ public class LuceneConfigProducer {
         return this.config;
     }
 
-    private Map<String, Analyzer> getAnalyzers() {
+    Map<String, Analyzer> getAnalyzers() {
         return new HashMap<String, Analyzer>() {{
             put( RuleIndexTerm.TERM,
                  new RuleAttributeNameAnalyzer( LUCENE_40 ) );
@@ -73,6 +74,8 @@ public class LuceneConfigProducer {
                  new RuleAttributeNameAnalyzer( LUCENE_40 ) );
 
             put( ProjectRootPathIndexTerm.TERM,
+                 new FilenameAnalyzer( LUCENE_40 ) );
+            put( LuceneIndex.CUSTOM_FIELD_FILENAME,
                  new FilenameAnalyzer( LUCENE_40 ) );
 
             put( PackageNameIndexTerm.TERM,

--- a/kie-drools-wb/kie-drools-wb-webapp/src/test/java/org/kie/workbench/drools/backend/server/LuceneConfigProducerTest.java
+++ b/kie-drools-wb/kie-drools-wb-webapp/src/test/java/org/kie/workbench/drools/backend/server/LuceneConfigProducerTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.drools.backend.server;
+
+import java.util.Map;
+
+import org.apache.lucene.analysis.Analyzer;
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.workbench.common.screens.datamodeller.model.index.terms.FieldTypeIndexTerm;
+import org.kie.workbench.common.screens.datamodeller.model.index.terms.JavaTypeIndexTerm;
+import org.kie.workbench.common.screens.datamodeller.model.index.terms.JavaTypeInterfaceIndexTerm;
+import org.kie.workbench.common.screens.datamodeller.model.index.terms.JavaTypeNameIndexTerm;
+import org.kie.workbench.common.screens.datamodeller.model.index.terms.JavaTypeParentIndexTerm;
+import org.kie.workbench.common.services.refactoring.backend.server.indexing.FullyQualifiedClassNameAnalyzer;
+import org.kie.workbench.common.services.refactoring.backend.server.indexing.RuleAttributeNameAnalyzer;
+import org.kie.workbench.common.services.refactoring.model.index.terms.PackageNameIndexTerm;
+import org.kie.workbench.common.services.refactoring.model.index.terms.ProjectRootPathIndexTerm;
+import org.kie.workbench.common.services.refactoring.model.index.terms.RuleAttributeIndexTerm;
+import org.kie.workbench.common.services.refactoring.model.index.terms.RuleAttributeValueIndexTerm;
+import org.kie.workbench.common.services.refactoring.model.index.terms.RuleIndexTerm;
+import org.kie.workbench.common.services.refactoring.model.index.terms.TypeIndexTerm;
+import org.uberfire.ext.metadata.backend.lucene.analyzer.FilenameAnalyzer;
+import org.uberfire.ext.metadata.backend.lucene.index.LuceneIndex;
+
+import static org.junit.Assert.*;
+
+public class LuceneConfigProducerTest {
+
+    private LuceneConfigProducer producer;
+
+    @Before
+    public void setup() {
+        this.producer = new LuceneConfigProducer();
+    }
+
+    @Test
+    public void checkDefaultAnalyzers() {
+        final Map<String, Analyzer> analyzers = producer.getAnalyzers();
+
+        assertEquals( 12,
+                      analyzers.size() );
+
+        assertTrue( analyzers.get( RuleIndexTerm.TERM ) instanceof RuleAttributeNameAnalyzer );
+        assertTrue( analyzers.get( RuleAttributeIndexTerm.TERM ) instanceof RuleAttributeNameAnalyzer );
+        assertTrue( analyzers.get( RuleAttributeValueIndexTerm.TERM ) instanceof RuleAttributeNameAnalyzer );
+
+        assertTrue( analyzers.get( ProjectRootPathIndexTerm.TERM ) instanceof FilenameAnalyzer );
+        assertTrue( analyzers.get( LuceneIndex.CUSTOM_FIELD_FILENAME ) instanceof FilenameAnalyzer );
+
+        assertTrue( analyzers.get( PackageNameIndexTerm.TERM ) instanceof FullyQualifiedClassNameAnalyzer );
+        assertTrue( analyzers.get( FieldTypeIndexTerm.TERM ) instanceof FullyQualifiedClassNameAnalyzer );
+        assertTrue( analyzers.get( JavaTypeIndexTerm.TERM ) instanceof FullyQualifiedClassNameAnalyzer );
+        assertTrue( analyzers.get( JavaTypeInterfaceIndexTerm.TERM ) instanceof FullyQualifiedClassNameAnalyzer );
+        assertTrue( analyzers.get( JavaTypeNameIndexTerm.TERM ) instanceof FullyQualifiedClassNameAnalyzer );
+        assertTrue( analyzers.get( JavaTypeParentIndexTerm.TERM ) instanceof FullyQualifiedClassNameAnalyzer );
+        assertTrue( analyzers.get( TypeIndexTerm.TERM ) instanceof FullyQualifiedClassNameAnalyzer );
+    }
+
+}

--- a/kie-wb-smoke-tests/kie-wb-smoke-tests-main/src/main/java/org/kie/smoke/wb/selenium/model/persps/AdministrationPerspective.java
+++ b/kie-wb-smoke-tests/kie-wb-smoke-tests-main/src/main/java/org/kie/smoke/wb/selenium/model/persps/AdministrationPerspective.java
@@ -21,7 +21,7 @@ import org.openqa.selenium.WebDriver;
 
 public class AdministrationPerspective extends AbstractPerspective {
 
-    private static final By REPOSITORY_EDITOR_TITLE = By.cssSelector("span[title='RepositoryEditor']");
+    private static final By REPOSITORY_EDITOR_TITLE = By.cssSelector("span[title='Repository Editor']");
     private static final By FILE_EXPLORER_CONTENT = By.cssSelector(" .fa-folder,.fa-folder-open");
 
     public AdministrationPerspective(WebDriver driver) {

--- a/kie-wb/kie-wb-webapp/src/main/java/org/kie/workbench/backend/LuceneConfigProducer.java
+++ b/kie-wb/kie-wb-webapp/src/main/java/org/kie/workbench/backend/LuceneConfigProducer.java
@@ -39,6 +39,7 @@ import org.kie.workbench.common.services.refactoring.model.index.terms.TypeIndex
 import org.uberfire.ext.metadata.backend.lucene.LuceneConfig;
 import org.uberfire.ext.metadata.backend.lucene.LuceneConfigBuilder;
 import org.uberfire.ext.metadata.backend.lucene.analyzer.FilenameAnalyzer;
+import org.uberfire.ext.metadata.backend.lucene.index.LuceneIndex;
 
 import static org.apache.lucene.util.Version.*;
 
@@ -63,7 +64,7 @@ public class LuceneConfigProducer {
         return this.config;
     }
 
-    private Map<String, Analyzer> getAnalyzers() {
+    Map<String, Analyzer> getAnalyzers() {
         return new HashMap<String, Analyzer>() {{
             put( RuleIndexTerm.TERM,
                  new RuleAttributeNameAnalyzer( LUCENE_40 ) );
@@ -73,6 +74,8 @@ public class LuceneConfigProducer {
                  new RuleAttributeNameAnalyzer( LUCENE_40 ) );
 
             put( ProjectRootPathIndexTerm.TERM,
+                 new FilenameAnalyzer( LUCENE_40 ) );
+            put( LuceneIndex.CUSTOM_FIELD_FILENAME,
                  new FilenameAnalyzer( LUCENE_40 ) );
 
             put( PackageNameIndexTerm.TERM,

--- a/kie-wb/kie-wb-webapp/src/test/java/org/kie/workbench/backend/LuceneConfigProducerTest.java
+++ b/kie-wb/kie-wb-webapp/src/test/java/org/kie/workbench/backend/LuceneConfigProducerTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.backend;
+
+import java.util.Map;
+
+import org.apache.lucene.analysis.Analyzer;
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.workbench.common.screens.datamodeller.model.index.terms.FieldTypeIndexTerm;
+import org.kie.workbench.common.screens.datamodeller.model.index.terms.JavaTypeIndexTerm;
+import org.kie.workbench.common.screens.datamodeller.model.index.terms.JavaTypeInterfaceIndexTerm;
+import org.kie.workbench.common.screens.datamodeller.model.index.terms.JavaTypeNameIndexTerm;
+import org.kie.workbench.common.screens.datamodeller.model.index.terms.JavaTypeParentIndexTerm;
+import org.kie.workbench.common.services.refactoring.backend.server.indexing.FullyQualifiedClassNameAnalyzer;
+import org.kie.workbench.common.services.refactoring.backend.server.indexing.RuleAttributeNameAnalyzer;
+import org.kie.workbench.common.services.refactoring.model.index.terms.PackageNameIndexTerm;
+import org.kie.workbench.common.services.refactoring.model.index.terms.ProjectRootPathIndexTerm;
+import org.kie.workbench.common.services.refactoring.model.index.terms.RuleAttributeIndexTerm;
+import org.kie.workbench.common.services.refactoring.model.index.terms.RuleAttributeValueIndexTerm;
+import org.kie.workbench.common.services.refactoring.model.index.terms.RuleIndexTerm;
+import org.kie.workbench.common.services.refactoring.model.index.terms.TypeIndexTerm;
+import org.uberfire.ext.metadata.backend.lucene.analyzer.FilenameAnalyzer;
+import org.uberfire.ext.metadata.backend.lucene.index.LuceneIndex;
+
+import static org.junit.Assert.*;
+
+public class LuceneConfigProducerTest {
+
+    private LuceneConfigProducer producer;
+
+    @Before
+    public void setup() {
+        this.producer = new LuceneConfigProducer();
+    }
+
+    @Test
+    public void checkDefaultAnalyzers() {
+        final Map<String, Analyzer> analyzers = producer.getAnalyzers();
+
+        assertEquals( 12,
+                      analyzers.size() );
+
+        assertTrue( analyzers.get( RuleIndexTerm.TERM ) instanceof RuleAttributeNameAnalyzer );
+        assertTrue( analyzers.get( RuleAttributeIndexTerm.TERM ) instanceof RuleAttributeNameAnalyzer );
+        assertTrue( analyzers.get( RuleAttributeValueIndexTerm.TERM ) instanceof RuleAttributeNameAnalyzer );
+
+        assertTrue( analyzers.get( ProjectRootPathIndexTerm.TERM ) instanceof FilenameAnalyzer );
+        assertTrue( analyzers.get( LuceneIndex.CUSTOM_FIELD_FILENAME ) instanceof FilenameAnalyzer );
+
+        assertTrue( analyzers.get( PackageNameIndexTerm.TERM ) instanceof FullyQualifiedClassNameAnalyzer );
+        assertTrue( analyzers.get( FieldTypeIndexTerm.TERM ) instanceof FullyQualifiedClassNameAnalyzer );
+        assertTrue( analyzers.get( JavaTypeIndexTerm.TERM ) instanceof FullyQualifiedClassNameAnalyzer );
+        assertTrue( analyzers.get( JavaTypeInterfaceIndexTerm.TERM ) instanceof FullyQualifiedClassNameAnalyzer );
+        assertTrue( analyzers.get( JavaTypeNameIndexTerm.TERM ) instanceof FullyQualifiedClassNameAnalyzer );
+        assertTrue( analyzers.get( JavaTypeParentIndexTerm.TERM ) instanceof FullyQualifiedClassNameAnalyzer );
+        assertTrue( analyzers.get( TypeIndexTerm.TERM ) instanceof FullyQualifiedClassNameAnalyzer );
+    }
+
+}


### PR DESCRIPTION
See https://issues.jboss.org/browse/RHBRMS-2598

Cherry-pick of https://github.com/droolsjbpm/kie-wb-common/pull/471 (of sorts) for 6.5.x (Code changes are similar but had to be applied manually to 6.5.x since it has a different code structure to master).