### PR TITLE
Add org.uberfire.start.method property to WAS assembly

### DIFF
--- a/kie-wb/kie-wb-distribution-wars/src/main/assembly/was8/README.md
+++ b/kie-wb/kie-wb-distribution-wars/src/main/assembly/was8/README.md
@@ -149,6 +149,7 @@ JVM Custom properties
 - org.kie.executor.jms.queue - {JNDI_NAME} -- JNDI name of the kie executor service JMS queue
 - org.kie.executor.jms.cf - {JNDI_NAME} -- JNDI name of the kie executor service JMS connection factory
 - org.apache.wink.jaxbcontextcache - off -- makes sure that the websphere apache wink framework does not cache JAXBContexts. This is unnecessary for performance and also interferes with the custom-type serialization for the REST APi
+- org.uberfire.start.method - value must be ejb
 
 Deploy the application
 --------------------------


### PR DESCRIPTION
Hello,

as discussed in [BXMSDOC-847](https://issues.jboss.org/browse/BXMSDOC-847), a property *org.uberfire.start.method* should be added to WAS assembly guide too. What do you think?

Marián
