### PR TITLE
[6.5.x] RHBRMS-2580 - REST API access control does not work on WebLogic

### DIFF
--- a/kie-drools-wb/kie-drools-wb-distribution-wars/src/main/assembly/weblogic12/WEB-INF/web.xml
+++ b/kie-drools-wb/kie-drools-wb-distribution-wars/src/main/assembly/weblogic12/WEB-INF/web.xml
@@ -123,8 +123,8 @@
     <servlet-class>com.sun.jersey.spi.container.servlet.ServletContainer</servlet-class>
     <!-- REST Permissions -->
     <init-param>
-      <param-name>jersey.config.server.provider.classnames</param-name>
-      <param-value>org.glassfish.jersey.server.filter.RolesAllowedDynamicFeature</param-value>
+      <param-name>com.sun.jersey.spi.container.ResourceFilters</param-name>
+      <param-value>com.sun.jersey.api.container.filter.RolesAllowedResourceFilterFactory</param-value>
     </init-param>
   </servlet>
   <servlet-mapping>


### PR DESCRIPTION
Fix for [RHBRMS-2580](https://issues.jboss.org/browse/RHBRMS-2580) proposed by @mswiderski. It has been tested with Business Central on WebLogic and really resolves the issue.