### PR TITLE
Add simple import, build & deploy project test to seleinum test suite

### DIFF
--- a/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/Persp.java
+++ b/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/Persp.java
@@ -18,6 +18,7 @@ package org.kie.wb.selenium.model;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+
 import org.kie.wb.selenium.model.persps.AbstractPerspective;
 import org.kie.wb.selenium.model.persps.AdministrationPerspective;
 import org.kie.wb.selenium.model.persps.AppsPerspective;
@@ -30,7 +31,6 @@ import org.kie.wb.selenium.model.persps.PeoplePerspective;
 import org.kie.wb.selenium.model.persps.PluginManagementPerspective;
 import org.kie.wb.selenium.model.persps.ProcessAndTaskDashboardPerspective;
 import org.kie.wb.selenium.model.persps.ProcessDefinitionsPerspective;
-import org.kie.wb.selenium.model.persps.ProcessDeploymentsPerspective;
 import org.kie.wb.selenium.model.persps.ProcessInstancesPerspective;
 import org.kie.wb.selenium.model.persps.ProjectAuthoringPerspective;
 import org.kie.wb.selenium.model.persps.RuleDeploymentsPerspective;
@@ -59,9 +59,6 @@ public class Persp<T extends AbstractPerspective> {
 
     public static final Persp<AdministrationPerspective> ADMINISTRATION
             = new Persp<>("Authoring", "Administration", AdministrationPerspective.class);
-
-    public static final Persp<ProcessDeploymentsPerspective> PROCESS_DEPLOYMENTS
-            = new Persp<>("Deploy", "Process Deployments", ProcessDeploymentsPerspective.class, true);
 
     public static final Persp<RuleDeploymentsPerspective> EXECUTION_SERVERS
             = new Persp<>("Deploy", "Execution Servers", RuleDeploymentsPerspective.class);

--- a/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/PrimaryNavbar.java
+++ b/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/PrimaryNavbar.java
@@ -14,8 +14,10 @@
  */
 package org.kie.wb.selenium.model;
 
-import org.jboss.arquillian.graphene.Graphene;
 import static org.kie.wb.selenium.model.KieSeleniumTest.driver;
+import static org.kie.wb.selenium.util.ByUtil.jquery;
+
+import org.jboss.arquillian.graphene.Graphene;
 import org.kie.wb.selenium.model.persps.AbstractPerspective;
 import org.kie.wb.selenium.model.persps.AdministrationPerspective;
 import org.kie.wb.selenium.model.persps.AppsPerspective;
@@ -28,15 +30,12 @@ import org.kie.wb.selenium.model.persps.PeoplePerspective;
 import org.kie.wb.selenium.model.persps.PluginManagementPerspective;
 import org.kie.wb.selenium.model.persps.ProcessAndTaskDashboardPerspective;
 import org.kie.wb.selenium.model.persps.ProcessDefinitionsPerspective;
-import org.kie.wb.selenium.model.persps.ProcessDeploymentsPerspective;
 import org.kie.wb.selenium.model.persps.ProcessInstancesPerspective;
 import org.kie.wb.selenium.model.persps.ProjectAuthoringPerspective;
 import org.kie.wb.selenium.model.persps.RuleDeploymentsPerspective;
 import org.kie.wb.selenium.model.persps.TasksPerspective;
 import org.kie.wb.selenium.model.persps.TimelinePerspective;
 import org.kie.wb.selenium.model.widgets.DropdownMenu;
-import static org.kie.wb.selenium.util.ByUtil.jquery;
-
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 import org.slf4j.Logger;
@@ -54,7 +53,7 @@ public class PrimaryNavbar {
     @FindBy(css = "li[title='Reset all Perspective layouts']+li")
     private DropdownMenu logoutMenu;
 
-    @FindBy(css = ".uf-workbench-layout > div:last-child")
+    @FindBy(css = ".uf-workbench-layout")
     private WebElement perspectiveRoot;
 
     public void logout() {
@@ -87,10 +86,6 @@ public class PrimaryNavbar {
 
     public AdministrationPerspective administration() {
         return navigateTo(Persp.ADMINISTRATION);
-    }
-
-    public ProcessDeploymentsPerspective processDeployments() {
-        return navigateTo(Persp.PROCESS_DEPLOYMENTS);
     }
 
     public RuleDeploymentsPerspective ruleDeployments() {

--- a/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/AbstractPerspective.java
+++ b/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/AbstractPerspective.java
@@ -15,10 +15,15 @@
  */
 package org.kie.wb.selenium.model.persps;
 
+import static org.kie.wb.selenium.util.ByUtil.jquery;
+
 import org.jboss.arquillian.graphene.Graphene;
 import org.jboss.arquillian.graphene.page.Page;
 import org.kie.wb.selenium.model.PageObject;
 import org.kie.wb.selenium.model.PrimaryNavbar;
+import org.kie.wb.selenium.model.widgets.Panel;
+import org.kie.wb.selenium.util.Waits;
+import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 
@@ -46,5 +51,11 @@ public abstract class AbstractPerspective extends PageObject {
      * Waiting for the perspective to be fully loaded. No-op by default.
      */
     public void waitForLoaded() {
+    }
+
+    public <T extends Panel> T createPanel(Class<T> panelClass, String title) {
+        By panelLoc = jquery(".uf-listbar-panel:contains('%s')", title);
+        WebElement panelRoot = Waits.elementPresent(panelLoc, 3);
+        return Graphene.createPageFragment(panelClass, panelRoot);
     }
 }

--- a/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/AdministrationPerspective.java
+++ b/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/AdministrationPerspective.java
@@ -25,12 +25,12 @@ public class AdministrationPerspective extends AbstractPerspective {
 
     @Override
     public void waitForLoaded() {
-        Waits.elementPresent(driver, FILE_EXPLORER_CONTENT);
+        Waits.elementPresent(FILE_EXPLORER_CONTENT);
         Waits.pause(1000);
     }
 
     @Override
     public boolean isDisplayed() {
-        return Waits.isElementPresent(driver, REPOSITORY_EDITOR_TITLE);
+        return Waits.isElementPresent(REPOSITORY_EDITOR_TITLE);
     }
 }

--- a/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/AppsPerspective.java
+++ b/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/AppsPerspective.java
@@ -24,6 +24,6 @@ public class AppsPerspective extends AbstractPerspective {
 
     @Override
     public boolean isDisplayed() {
-        return Waits.isElementPresent(driver, HOME_LINK);
+        return Waits.isElementPresent(HOME_LINK);
     }
 }

--- a/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/ArtifactRepositoryPerspective.java
+++ b/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/ArtifactRepositoryPerspective.java
@@ -15,6 +15,8 @@
  */
 package org.kie.wb.selenium.model.persps;
 
+import static org.kie.wb.selenium.util.ByUtil.jquery;
+
 import org.kie.wb.selenium.util.Waits;
 import org.openqa.selenium.By;
 
@@ -24,6 +26,10 @@ public class ArtifactRepositoryPerspective extends AbstractPerspective {
 
     @Override
     public boolean isDisplayed() {
-        return Waits.isElementPresent(driver, NAME_COLUMN_HEADER);
+        return Waits.isElementPresent(NAME_COLUMN_HEADER);
+    }
+
+    public boolean isArtifactPresent(String gav) {
+        return Waits.isElementPresent(jquery("tr[__gwt_row]:contains('%s')", gav), 5);
     }
 }

--- a/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/ContributorsPerspective.java
+++ b/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/ContributorsPerspective.java
@@ -24,6 +24,6 @@ public class ContributorsPerspective extends AbstractPerspective {
 
     @Override
     public boolean isDisplayed() {
-        return Waits.isElementPresent(driver, CHART_TITLE);
+        return Waits.isElementPresent(CHART_TITLE);
     }
 }

--- a/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/HomePerspective.java
+++ b/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/HomePerspective.java
@@ -28,13 +28,13 @@ public class HomePerspective extends AbstractPerspective {
 
     @Override
     public void waitForLoaded() {
-        Waits.elementPresent(driver, CAROUSEL, HOME_PERSP_LOADING_TIMEOUT_SECONDS);
+        Waits.elementPresent(CAROUSEL, HOME_PERSP_LOADING_TIMEOUT_SECONDS);
     }
 
     @Override
     public boolean isDisplayed() {
         try {
-            Waits.elementPresent(driver, CAROUSEL, 2);
+            Waits.elementPresent(CAROUSEL, 2);
             return true;
         } catch (NoSuchElementException nse) {
             return false;

--- a/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/JobsPerspective.java
+++ b/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/JobsPerspective.java
@@ -24,6 +24,6 @@ public class JobsPerspective extends AbstractPerspective {
 
     @Override
     public boolean isDisplayed() {
-        return Waits.isElementPresent(driver, ID_COLUMN_HEADER);
+        return Waits.isElementPresent(ID_COLUMN_HEADER);
     }
 }

--- a/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/PeoplePerspective.java
+++ b/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/PeoplePerspective.java
@@ -24,6 +24,6 @@ public class PeoplePerspective extends AbstractPerspective {
 
     @Override
     public boolean isDisplayed() {
-        return Waits.isElementPresent(driver, PROFILE_HOME_BUTTON);
+        return Waits.isElementPresent(PROFILE_HOME_BUTTON);
     }
 }

--- a/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/PluginManagementPerspective.java
+++ b/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/PluginManagementPerspective.java
@@ -24,6 +24,6 @@ public class PluginManagementPerspective extends AbstractPerspective {
 
     @Override
     public boolean isDisplayed() {
-        return Waits.isElementPresent(driver, PLUGINS_EXPLORER_TITLE);
+        return Waits.isElementPresent(PLUGINS_EXPLORER_TITLE);
     }
 }

--- a/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/ProcessAndTaskDashboardPerspective.java
+++ b/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/ProcessAndTaskDashboardPerspective.java
@@ -26,7 +26,7 @@ public class ProcessAndTaskDashboardPerspective extends AbstractPerspective {
 
     @Override
     public boolean isDisplayed() {
-        return Waits.isElementPresent(driver, PROCESSES_TAB);
+        return Waits.isElementPresent(PROCESSES_TAB);
     }
 
     @Override

--- a/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/ProcessDefinitionsPerspective.java
+++ b/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/ProcessDefinitionsPerspective.java
@@ -24,6 +24,6 @@ public class ProcessDefinitionsPerspective extends AbstractPerspective {
 
     @Override
     public boolean isDisplayed() {
-        return Waits.isElementPresent(driver, PROC_DEFS_TITLE);
+        return Waits.isElementPresent(PROC_DEFS_TITLE);
     }
 }

--- a/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/ProcessInstancesPerspective.java
+++ b/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/ProcessInstancesPerspective.java
@@ -29,7 +29,7 @@ public class ProcessInstancesPerspective extends AbstractPerspective {
 
     @Override
     public boolean isDisplayed() {
-        return Waits.isElementPresent(driver, PROC_INST_TITLE);
+        return Waits.isElementPresent(PROC_INST_TITLE);
     }
 
     @Override

--- a/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/ProjectAuthoringPerspective.java
+++ b/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/ProjectAuthoringPerspective.java
@@ -15,22 +15,50 @@
  */
 package org.kie.wb.selenium.model.persps;
 
+import org.jboss.arquillian.graphene.findby.FindByJQuery;
+import org.kie.wb.selenium.model.persps.authoring.ImportExampleModal;
+import org.kie.wb.selenium.model.persps.authoring.ProjectEditor;
+import org.kie.wb.selenium.model.persps.authoring.ProjectExplorer;
+import org.kie.wb.selenium.model.widgets.ContextNavbar;
+import org.kie.wb.selenium.util.Repository;
 import org.kie.wb.selenium.util.Waits;
 import org.openqa.selenium.By;
+import org.openqa.selenium.support.FindBy;
 
 public class ProjectAuthoringPerspective extends AbstractPerspective {
 
     private static final By PROJECT_EXPLORER_TITLE = By.xpath("//h3[contains(text(),'Project Explorer')]");
-    //Project explorer bradcrumb toggle, whose presence indicates that PEX content has been loaded
+    //Project explorer breadcrumb toggle, whose presence indicates that PEX content has been loaded
     private static final By PEX_BREADCRUMB_TOGGLE = By.cssSelector(".fa-chevron-down");
+
+    @FindByJQuery(".nav.uf-perspective-context-menu")
+    private ContextNavbar contextNavbar;
+    @FindBy(xpath = "//div[div/h3[contains(text(),'Project Explorer')]]")
+    private ProjectExplorer projectExplorer;
 
     @Override
     public void waitForLoaded() {
-        Waits.elementPresent(driver, PEX_BREADCRUMB_TOGGLE, 10);
+        Waits.elementPresent(PEX_BREADCRUMB_TOGGLE, 10);
     }
 
     @Override
     public boolean isDisplayed() {
-        return Waits.isElementPresent(driver, PROJECT_EXPLORER_TITLE);
+        return Waits.isElementPresent(PROJECT_EXPLORER_TITLE);
+    }
+
+    public void importExampleProject(Repository repo, String targetRepo, String targetOrgUnit, String... projects) {
+        ImportExampleModal modal = contextNavbar.importExample();
+        modal.selectRepo(repo.getUrl());
+        modal.selectProjects(projects);
+        modal.setTargetRepoAndOrgUnit(targetRepo, targetOrgUnit);
+    }
+
+    public ProjectExplorer getProjectExplorer() {
+        return projectExplorer;
+    }
+
+    public ProjectEditor openProjectEditor() {
+        getProjectExplorer().openProjectEditor();
+        return createPanel(ProjectEditor.class, "Project:");
     }
 }

--- a/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/RuleDeploymentsPerspective.java
+++ b/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/RuleDeploymentsPerspective.java
@@ -26,7 +26,7 @@ public class RuleDeploymentsPerspective extends AbstractPerspective {
     @Override
     public boolean isDisplayed() {
         try {
-            return Waits.isElementPresent(driver, SERVER_MNGMT_SCREEN_ITEM);
+            return Waits.isElementPresent(SERVER_MNGMT_SCREEN_ITEM);
         } catch (Exception ex) {
             ex.printStackTrace();
         }

--- a/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/TasksPerspective.java
+++ b/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/TasksPerspective.java
@@ -28,7 +28,7 @@ public class TasksPerspective extends AbstractPerspective {
 
     @Override
     public boolean isDisplayed() {
-        return Waits.isElementPresent(driver, ACTIVE_FILTER_TITLE);
+        return Waits.isElementPresent(ACTIVE_FILTER_TITLE);
     }
 
     @Override

--- a/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/TimelinePerspective.java
+++ b/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/TimelinePerspective.java
@@ -24,6 +24,6 @@ public class TimelinePerspective extends AbstractPerspective {
 
     @Override
     public boolean isDisplayed() {
-        return Waits.isElementPresent(driver, LATEST_CHANGES_TITLE);
+        return Waits.isElementPresent(LATEST_CHANGES_TITLE);
     }
 }

--- a/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/authoring/ConflictingRepositoriesModal.java
+++ b/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/authoring/ConflictingRepositoriesModal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2016 JBoss by Red Hat.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,17 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.kie.wb.selenium.model.persps;
+package org.kie.wb.selenium.model.persps.authoring;
 
-import org.kie.wb.selenium.util.Waits;
-import org.openqa.selenium.By;
+import org.kie.wb.selenium.model.widgets.ModalDialog;
 
-public class DataSetsPerspective extends AbstractPerspective {
+public class ConflictingRepositoriesModal extends ModalDialog {
 
-    private static final By NEW_DS_LINK = By.linkText("new data set");
+    public static ConflictingRepositoriesModal newInstance() {
+        return ModalDialog.newInstance(ConflictingRepositoriesModal.class, "Conflicting Repositories");
+    }
 
-    @Override
-    public boolean isDisplayed() {
-        return Waits.isElementPresent(NEW_DS_LINK);
+    public void overrideArtifactInMavenRepo() {
+        clickButton("Override");
+        waitForDisappearance();
     }
 }

--- a/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/authoring/ImportExampleModal.java
+++ b/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/authoring/ImportExampleModal.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2016 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.wb.selenium.model.persps.authoring;
+
+import org.jboss.arquillian.graphene.findby.FindByJQuery;
+import org.kie.wb.selenium.model.widgets.ModalDialog;
+import org.kie.wb.selenium.util.ByUtil;
+import org.kie.wb.selenium.util.Waits;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+
+
+public class ImportExampleModal extends ModalDialog {
+
+    @FindByJQuery("#repositoryDropdown > input")
+    private WebElement repoUrlInput;
+    @FindByJQuery("#targetRepositoryTextBox")
+    private WebElement targetRepoInput;
+    @FindByJQuery("#organizationalUnitsDropdown > input")
+    private WebElement targetOrgUnit;
+
+    public static ImportExampleModal newInstance() {
+        return ModalDialog.newInstance(ImportExampleModal.class, "Import Example");
+    }
+
+    public void selectRepo(String repoUrl) {
+        repoUrlInput.clear();
+        repoUrlInput.sendKeys(repoUrl);
+        next();
+        Waits.elementPresent(By.id("projects"));
+    }
+
+    public void selectProjects(String... projects) {
+        for (String proj : projects) {
+            selectProject(proj);
+        }
+        next();
+    }
+
+    private void selectProject(String project) {
+        By projCheckboxLoc = ByUtil.xpath("//input[following-sibling::span[contains(text(),'%s')]]", project);
+        WebElement checkbox = Waits.elementPresent(projCheckboxLoc, 10);
+        checkbox.click();
+    }
+
+    public void setTargetRepoAndOrgUnit(String repoName, String orgUnit) {
+        targetRepoInput.sendKeys(repoName);
+        targetOrgUnit.sendKeys(orgUnit);
+        targetRepoInput.click(); //workaround to fire onchange event or something //TODO report not user friendly
+        finish();
+    }
+}

--- a/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/authoring/ProjectEditor.java
+++ b/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/authoring/ProjectEditor.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2016 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.wb.selenium.model.persps.authoring;
+
+import org.kie.wb.selenium.model.widgets.Panel;
+import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.TimeoutException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ProjectEditor extends Panel {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ProjectEditor.class);
+
+    public void buildAndDeploy() {
+        getToolbar().buildAndDeploy();
+        possiblyOverrideGavConflict();
+    }
+
+    private void possiblyOverrideGavConflict() {
+        try {
+            ConflictingRepositoriesModal modal = ConflictingRepositoriesModal.newInstance();
+            modal.overrideArtifactInMavenRepo();
+        } catch (TimeoutException | NoSuchElementException ignored) {
+            LOG.warn("Modal showing GAV conflict didn't appear");
+        }
+    }
+}

--- a/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/authoring/ProjectExplorer.java
+++ b/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/persps/authoring/ProjectExplorer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2016 JBoss by Red Hat.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,17 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.kie.wb.selenium.model.persps;
+package org.kie.wb.selenium.model.persps.authoring;
 
-import org.kie.wb.selenium.util.Waits;
-import org.openqa.selenium.By;
+import org.jboss.arquillian.graphene.findby.FindByJQuery;
+import org.openqa.selenium.WebElement;
 
-public class ProcessDeploymentsPerspective extends AbstractPerspective {
+public class ProjectExplorer {
 
-    private static final By PROC_DEPLS_TITLE = By.cssSelector("span[title='Deployed Units']");
+    @FindByJQuery("button:contains('Open Project Editor')")
+    private WebElement openPexButton;
 
-    @Override
-    public boolean isDisplayed() {
-        return Waits.isElementPresent(driver, PROC_DEPLS_TITLE);
+    public void openProjectEditor() {
+        openPexButton.click();
     }
 }

--- a/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/widgets/ContextNavbar.java
+++ b/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/widgets/ContextNavbar.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2016 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.wb.selenium.model.widgets;
+
+import org.jboss.arquillian.graphene.fragment.Root;
+import org.kie.wb.selenium.model.persps.authoring.ImportExampleModal;
+import org.kie.wb.selenium.util.Waits;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+
+public class ContextNavbar {
+
+    @Root
+    private WebElement navbarRoot;
+
+    @FindBy(linkText = "Example")
+    private WebElement exampleButton;
+
+    public ImportExampleModal importExample() {
+        Waits.elementPresent(navbarRoot);
+        navbarRoot.isDisplayed();
+
+        exampleButton.click();
+        return ImportExampleModal.newInstance();
+    }
+}

--- a/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/widgets/ModalDialog.java
+++ b/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/widgets/ModalDialog.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2016 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.wb.selenium.model.widgets;
+
+import static org.kie.wb.selenium.util.ByUtil.jquery;
+
+import org.jboss.arquillian.graphene.Graphene;
+import org.jboss.arquillian.graphene.findby.FindByJQuery;
+import org.kie.wb.selenium.model.PageObject;
+import org.kie.wb.selenium.util.Waits;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+public class ModalDialog extends PageObject {
+
+    @FindByJQuery("button.close")
+    private WebElement closeButton;
+
+    public static <T extends ModalDialog> T newInstance(Class<T> pageFragmentClass, String modalTitle) {
+        By modalRootLocator = jquery(".modal-content:has(.modal-header:contains('%s'))", modalTitle);
+        WebElement modalRoot = Waits.elementPresent(modalRootLocator, 3);
+        return Graphene.createPageFragment(pageFragmentClass, modalRoot);
+    }
+
+    public void close() {
+        closeButton.click();
+    }
+
+    public void ok() {
+        clickButton("Ok");
+        waitForDisappearance();
+    }
+
+    public void finish() {
+        clickButton("Finish");
+        waitForDisappearance();
+    }
+
+    public void next() {
+        clickButton("Next");
+    }
+
+    public void clickButton(String buttonText) {
+        By buttonLoc = jquery(".modal-footer > .btn:contains('%s'):not([disabled])", buttonText);
+        WebElement button = Waits.elementPresent(buttonLoc);
+        button.click();
+    }
+
+    protected void waitForDisappearance() {
+        Waits.elementAbsent(By.cssSelector(".modal.in"));
+    }
+}

--- a/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/widgets/Panel.java
+++ b/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/widgets/Panel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2016 JBoss by Red Hat.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,17 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.kie.wb.selenium.model.persps;
+package org.kie.wb.selenium.model.widgets;
 
-import org.kie.wb.selenium.util.Waits;
-import org.openqa.selenium.By;
+import org.jboss.arquillian.graphene.findby.FindByJQuery;
 
-public class DataSetsPerspective extends AbstractPerspective {
+public class Panel {
 
-    private static final By NEW_DS_LINK = By.linkText("new data set");
+    @FindByJQuery(".uf-listbar-panel-header-toolbar")
+    private PanelToolbar toolbar;
 
-    @Override
-    public boolean isDisplayed() {
-        return Waits.isElementPresent(NEW_DS_LINK);
+    public PanelToolbar getToolbar() {
+        return toolbar;
     }
 }

--- a/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/widgets/PanelToolbar.java
+++ b/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/model/widgets/PanelToolbar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2016 JBoss by Red Hat.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,17 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.kie.wb.selenium.model.persps;
+package org.kie.wb.selenium.model.widgets;
 
-import org.kie.wb.selenium.util.Waits;
-import org.openqa.selenium.By;
+import org.jboss.arquillian.graphene.findby.FindByJQuery;
 
-public class DataSetsPerspective extends AbstractPerspective {
+public class PanelToolbar {
 
-    private static final By NEW_DS_LINK = By.linkText("new data set");
+    @FindByJQuery(".btn-group:last-child:contains('Build')")
+    private DropdownMenu buildMenu;
 
-    @Override
-    public boolean isDisplayed() {
-        return Waits.isElementPresent(NEW_DS_LINK);
+    public void buildAndDeploy() {
+        buildMenu.selectItem("Build & Deploy");
     }
 }

--- a/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/util/GrapheneUtil.java
+++ b/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/util/GrapheneUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2016 JBoss by Red Hat.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,17 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.kie.wb.selenium.model.persps;
+package org.kie.wb.selenium.util;
 
-import org.kie.wb.selenium.util.Waits;
-import org.openqa.selenium.By;
+import org.jboss.arquillian.drone.api.annotation.Default;
+import org.jboss.arquillian.graphene.context.GrapheneContext;
+import org.openqa.selenium.TakesScreenshot;
+import org.openqa.selenium.WebDriver;
 
-public class DataSetsPerspective extends AbstractPerspective {
+public class GrapheneUtil {
 
-    private static final By NEW_DS_LINK = By.linkText("new data set");
-
-    @Override
-    public boolean isDisplayed() {
-        return Waits.isElementPresent(NEW_DS_LINK);
+    public static WebDriver getDriver() {
+        return GrapheneContext.getContextFor(Default.class).getWebDriver(TakesScreenshot.class);
     }
 }

--- a/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/util/Repository.java
+++ b/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/util/Repository.java
@@ -1,29 +1,32 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *       http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- */
-package org.kie.wb.selenium.model.persps;
+*/
+package org.kie.wb.selenium.util;
 
-import org.kie.wb.selenium.util.Waits;
-import org.openqa.selenium.By;
+public enum Repository {
 
-public class DataSetsPerspective extends AbstractPerspective {
+    JBPM_PLAYGROUND("https://github.com/guvnorngtestuser1/jbpm-console-ng-playground-kjar.git"),
+    GUVNOR_PLAYGROUND("https://github.com/guvnorngtestuser1/guvnorng-playground.git");
 
-    private static final By NEW_DS_LINK = By.linkText("new data set");
+    private final String url;
 
-    @Override
-    public boolean isDisplayed() {
-        return Waits.isElementPresent(NEW_DS_LINK);
+    Repository(String url) {
+        this.url = url;
+    }
+
+    public String getUrl() {
+        return url;
     }
 }

--- a/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/util/ScreenshotOnFailure.java
+++ b/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/util/ScreenshotOnFailure.java
@@ -15,16 +15,16 @@
  */
 package org.kie.wb.selenium.util;
 
+import static org.kie.wb.selenium.util.GrapheneUtil.getDriver;
+
 import java.io.File;
 import java.io.IOException;
+
 import org.apache.commons.io.FileUtils;
-import org.jboss.arquillian.drone.api.annotation.Default;
-import org.jboss.arquillian.graphene.context.GrapheneContext;
 import org.junit.rules.TestWatcher;
 import org.junit.runner.Description;
 import org.openqa.selenium.OutputType;
 import org.openqa.selenium.TakesScreenshot;
-import org.openqa.selenium.WebDriver;
 
 /**
  * JUnit Rule for taking screenshots/saving page HTML source of browser content
@@ -55,7 +55,7 @@ public class ScreenshotOnFailure extends TestWatcher {
     }
 
     private void savePageHtmlSource(String filename) {
-        String pageSource = getDriver().getPageSource();
+        String pageSource = GrapheneUtil.getDriver().getPageSource();
         File targetFile = new File(screenshotDir, filename + ".html");
         try {
             FileUtils.writeStringToFile(targetFile, pageSource, "UTF-8");
@@ -82,9 +82,5 @@ public class ScreenshotOnFailure extends TestWatcher {
             throw new IllegalStateException("The screenshotDir must be writable" + scd);
         }
         return scd;
-    }
-
-    private WebDriver getDriver() {
-        return GrapheneContext.getContextFor(Default.class).getWebDriver(TakesScreenshot.class);
     }
 }

--- a/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/util/Waits.java
+++ b/kie-wb-tests/kie-wb-tests-gui/src/main/java/org/kie/wb/selenium/util/Waits.java
@@ -17,7 +17,6 @@ package org.kie.wb.selenium.util;
 
 import org.openqa.selenium.By;
 import org.openqa.selenium.NoSuchElementException;
-import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
@@ -26,39 +25,53 @@ public class Waits {
 
     private static final int DEFAULT_TIMEOUT = 15;
 
-    public static void elementVisible(WebDriver driver, By locator, int timeoutSeconds) {
-        new WebDriverWait(driver, timeoutSeconds)
+    public static void elementVisible(By locator, int timeoutSeconds) {
+        new WebDriverWait(GrapheneUtil.getDriver(), timeoutSeconds)
                 .until(ExpectedConditions.visibilityOfElementLocated(locator));
     }
 
-    public static WebElement elementPresent(WebDriver driver, By locator, int timeoutSeconds) {
-        WebElement elementPresent = new WebDriverWait(driver, timeoutSeconds)
+    public static WebElement elementPresent(By locator, int timeoutSeconds) {
+        WebElement elementPresent = new WebDriverWait(GrapheneUtil.getDriver(), timeoutSeconds)
                 .until(ExpectedConditions.presenceOfElementLocated(locator));
         return elementPresent;
     }
 
-    public static WebElement elementPresent(WebDriver driver, By locator) {
-        return elementPresent(driver, locator, DEFAULT_TIMEOUT);
+    public static WebElement elementPresent(By locator) {
+        return elementPresent(locator, DEFAULT_TIMEOUT);
     }
 
-    public static WebElement elementClickable(WebDriver driver, By locator) {
-        WebElement clickableElement = new WebDriverWait(driver, DEFAULT_TIMEOUT)
+    public static WebElement elementPresent(WebElement element) {
+        return new WebDriverWait(GrapheneUtil.getDriver(), DEFAULT_TIMEOUT)
+                .until(ExpectedConditions.visibilityOf(element));
+    }
+
+    public static void elementAbsent(By locator) {
+        new WebDriverWait(GrapheneUtil.getDriver(), DEFAULT_TIMEOUT)
+                .until(ExpectedConditions.numberOfElementsToBe(locator, 0));
+    }
+
+    public static WebElement elementClickable(By locator) {
+        WebElement clickableElement = new WebDriverWait(GrapheneUtil.getDriver(), DEFAULT_TIMEOUT)
                 .until(ExpectedConditions.elementToBeClickable(locator));
         return clickableElement;
     }
 
-    public static boolean isElementPresent(WebDriver driver, By locator) {
+    public static boolean isElementPresent(By locator, int timeoutSeconds) {
         try {
-            elementPresent(driver, locator);
+            elementPresent(locator, timeoutSeconds);
             return true;
         } catch (NoSuchElementException nse) {
             return false;
         }
     }
 
-    public static void pause(int miliseconds) {
+    public static boolean isElementPresent(By locator) {
+        return isElementPresent(locator, DEFAULT_TIMEOUT);
+    }
+
+    public static void pause(int milliseconds) {
         try {
-            Thread.sleep(miliseconds);
+            Thread.sleep(milliseconds);
         } catch (InterruptedException ex) {
             System.err.println("Pause interrupted");
         }

--- a/kie-wb-tests/kie-wb-tests-gui/src/test/filtered-resources/arquillian.xml
+++ b/kie-wb-tests/kie-wb-tests-gui/src/test/filtered-resources/arquillian.xml
@@ -19,5 +19,8 @@ limitations under the License.
   <extension qualifier="webdriver">
     <property name="browser">${browser}</property>
     <property name="waitModelInterval">15</property>
+    <!-- IE specific -->
+    <property name="ignoreProtectedModeSettings">false</property>
+    <property name="ie.ensureCleanSession">true</property>
   </extension>
 </arquillian>

--- a/kie-wb-tests/kie-wb-tests-gui/src/test/java/org/kie/wb/selenium/ui/ProjectAuthoringIntegrationTest.java
+++ b/kie-wb-tests/kie-wb-tests-gui/src/test/java/org/kie/wb/selenium/ui/ProjectAuthoringIntegrationTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2016 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.wb.selenium.ui;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+import org.kie.wb.selenium.model.KieSeleniumTest;
+import org.kie.wb.selenium.model.persps.ArtifactRepositoryPerspective;
+import org.kie.wb.selenium.model.persps.HomePerspective;
+import org.kie.wb.selenium.model.persps.ProjectAuthoringPerspective;
+import org.kie.wb.selenium.model.persps.authoring.ProjectEditor;
+import org.kie.wb.selenium.util.Repository;
+import org.kie.wb.selenium.util.Waits;
+
+public class ProjectAuthoringIntegrationTest extends KieSeleniumTest {
+
+    @Test
+    public void importAndBuildProject() {
+        HomePerspective home = login.loginDefaultUser();
+        ProjectAuthoringPerspective authoring = home.getNavbar().projectAuthoring();
+        authoring.importExampleProject(Repository.JBPM_PLAYGROUND, "MyRepo", "MyOrgUnit", "Evaluation");
+        ProjectEditor pe = authoring.openProjectEditor();
+        pe.buildAndDeploy();
+        Waits.pause(10_000); //Wait for project to build/deploy and appear in artifact repository perspective
+
+        ArtifactRepositoryPerspective artifactRepo = authoring.getNavbar().artifactRepository();
+        assertThat(artifactRepo.isArtifactPresent("org.jbpm:Evaluation:1.0"))
+                .as("project artifact should be present after build & deploy").isTrue();
+    }
+}

--- a/kie-wb-tests/kie-wb-tests-gui/src/test/resources/driver-binary-urls.xml
+++ b/kie-wb-tests/kie-wb-tests-gui/src/test/resources/driver-binary-urls.xml
@@ -2,7 +2,7 @@
 <root>
   <windows>
     <driver id="internetexplorer">
-      <version id="2.46.0"> <!-- The versions of these binaries are unfortunately
+      <version id="2.53.1 "> <!-- The versions of these binaries are unfortunately
          NOT kept in sync with selenium version. E.g. we can have selenium version 2.46.2,
          but we have to use IEDriverServer version 2.46.0-->
         <bitrate sixtyfourbit="true" thirtytwobit="true">
@@ -10,8 +10,8 @@
            There is a known issue with 64bit binary that makes typing into input elements very slow (1 character per 5 seconds)
            https://code.google.com/p/selenium/issues/detail?id=5116
           -->
-          <filelocation>http://selenium-release.storage.googleapis.com/2.46/IEDriverServer_Win32_2.46.0.zip</filelocation>
-          <hash>93616ec22088413ff9d8dec978d94474</hash>
+          <filelocation>http://selenium-release.storage.googleapis.com/2.53/IEDriverServer_Win32_2.53.1.zip</filelocation>
+          <hash>35ac005f9088f2995d6a1cdc384fe4cb</hash>
           <hashtype>md5</hashtype>
         </bitrate>
       </version>


### PR DESCRIPTION
The "meat" of this PR is `ProjectAuthoringIntegrationTest` which imports Evaluation project from jbpm-playground, does build & deploy (just to m2 repo, no kie-server) and checks in artifact repo perspective that project has been installed. 

Also udpated IEDriverServer version to match selenium version we're using and removed ProcessDeploymentsPerspective which is no longer present in the workbench.

Executed the selenium tests in this module with IE 10x on CI windows machine with no failures.