### PR TITLE
[6.5.x] RHBPMS-4129: Unlocalized 'Please wait. Loading application...' spinner

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,7 @@
           </includes>
           <excludes>
             <exclude>**/ErraiApp.properties</exclude>
+            <exclude>**/LoginConstants*.properties</exclude>
           </excludes>
           <replacements>
             <replacement>
@@ -121,7 +122,7 @@
         <configuration>
           <includes>
             <include>kie-wb/kie-wb-webapp/src/main/resources/org/kie/workbench/client/resources/i18n/LoginConstants*.properties</include>
-            <include>kie-drools-wb-webapp/src/main/resources/org/kie/workbench/drools/client/resources/i18n/LoginConstants*.properties</include>
+            <include>kie-drools-wb/kie-drools-wb-webapp/src/main/resources/org/kie/workbench/drools/client/resources/i18n/LoginConstants*.properties</include>
           </includes>
           <workDir>.</workDir>
           <tempDir>.</tempDir>


### PR DESCRIPTION
See https://issues.jboss.org/browse/RHBPMS-4129

Ensure LoginConstants is not processed by replacer plugin

(cherry picked from commit fcd9a08a48882da182638fc6749c062c3b83d87a)

This is the corollary of https://github.com/droolsjbpm/kie-wb-distributions/pull/389 for 6.5.x.