### PR TITLE
Increase memory for full profile GWT build

### DIFF
--- a/kie-drools-wb/kie-drools-wb-webapp/pom.xml
+++ b/kie-drools-wb/kie-drools-wb-webapp/pom.xml
@@ -1958,7 +1958,7 @@
         </property>
       </activation>
       <properties>
-        <gwt.memory.settings>-Xmx3g -Xms1g -Xss1M</gwt.memory.settings>
+        <gwt.memory.settings>-Xmx4g -Xms1g -Xss1M</gwt.memory.settings>
         <gwt.compiler.localWorkers>4</gwt.compiler.localWorkers>
       </properties>
       <build>

--- a/kie-wb/kie-wb-webapp/pom.xml
+++ b/kie-wb/kie-wb-webapp/pom.xml
@@ -2455,7 +2455,7 @@
         </property>
       </activation>
       <properties>
-        <gwt.memory.settings>-Xmx3g -Xms1g -Xss1M</gwt.memory.settings>
+        <gwt.memory.settings>-Xmx4g -Xms1g -Xss1M</gwt.memory.settings>
         <gwt.compiler.localWorkers>4</gwt.compiler.localWorkers>
       </properties>
       <build>


### PR DESCRIPTION
Jenkins keeps running OOM when running the full profile GWT build. This started yesterday. I can't reproduce locally (using either profile) but suggest to increase memory of the full profile to match the default profile settings (for now).

@psiroky can you take a look, please?

As a side note, I noticed that we're building 14 different permutations in the full profile. I doubt that this is still necessary, but I need to investigate separately. It seems to me that we can bring the build time down significantly.
