### PR TITLE
Remove escaping of single apostrophe as these i18n files are not used by GWT and hence do not need escaping

### DIFF
--- a/kie-drools-wb/kie-drools-wb-webapp/src/main/resources/org/kie/workbench/drools/client/resources/i18n/LoginConstants_fr.properties
+++ b/kie-drools-wb/kie-drools-wb-webapp/src/main/resources/org/kie/workbench/drools/client/resources/i18n/LoginConstants_fr.properties
@@ -1,5 +1,5 @@
 # translation auto-copied from project KIE webapp distributions, version 6.0.0, document org.kie/kie-drools-wb-webapp/org/kie/workbench/drools/client/resources/i18n/LoginConstants, author nmirasch
-UserName=Nom d''utilisateur
+UserName=Nom d'utilisateur
 # translation auto-copied from project KIE webapp distributions, version 6.0.0, document org.kie/kie-drools-wb-webapp/org/kie/workbench/drools/client/resources/i18n/LoginConstants, author nmirasch
 Password=Mot de passe
 # translation auto-copied from project KIE webapp distributions, version 6.0.0, document org.kie/kie-drools-wb-webapp/org/kie/workbench/drools/client/resources/i18n/LoginConstants, author nmirasch
@@ -9,10 +9,10 @@ LoginTitle=KIE Drools Workbench
 # translation auto-copied from project KIE webapp distributions, version 6.0.0, document org.kie/kie-drools-wb-webapp/org/kie/workbench/drools/client/resources/i18n/LoginConstants, author nmirasch
 loginFailed=La connexion a \u00e9chou\u00e9 \: non autoris\u00e9
 # translation auto-copied from project KIE webapp distributions, version 6.0.0, document org.kie/kie-drools-wb-webapp/org/kie/workbench/drools/client/resources/i18n/LoginConstants, author nmirasch
-loginAsAnotherUser=Connectez-vous en tant qu''autre utilisateur
+loginAsAnotherUser=Connectez-vous en tant qu'autre utilisateur
 # translation auto-copied from project KIE webapp distributions, version 6.2.0, document org.kie/kie-drools-wb-webapp/org/kie/workbench/drools/client/resources/i18n/LoginConstants, author croe@redhat.com
 logoutSuccssful=D\u00e9connexion r\u00e9ussie
 # translation auto-copied from project KIE webapp distributions, version 6.2.0, document org.kie/kie-drools-wb-webapp/org/kie/workbench/drools/client/resources/i18n/LoginConstants, author croe@redhat.com
 loginAgain=Connectez-vous \u00e0 nouveau
 loadingPleaseWait=Veuillez patienter
-loadingApplication=Chargement de l''application...
+loadingApplication=Chargement de l'application...

--- a/kie-wb/kie-wb-webapp/src/main/resources/org/kie/workbench/client/resources/i18n/LoginConstants_fr.properties
+++ b/kie-wb/kie-wb-webapp/src/main/resources/org/kie/workbench/client/resources/i18n/LoginConstants_fr.properties
@@ -1,5 +1,5 @@
 # translation auto-copied from project KIE webapp distributions, version 6.0.0, document org.kie/kie-wb-webapp/org/kie/workbench/client/resources/i18n/LoginConstants, author nmirasch
-UserName=Nom d''utilisateur
+UserName=Nom d'utilisateur
 # translation auto-copied from project KIE webapp distributions, version 6.0.0, document org.kie/kie-wb-webapp/org/kie/workbench/client/resources/i18n/LoginConstants, author nmirasch
 Password=Mot de passe
 # translation auto-copied from project KIE webapp distributions, version 6.0.0, document org.kie/kie-wb-webapp/org/kie/workbench/client/resources/i18n/LoginConstants, author nmirasch
@@ -9,10 +9,10 @@ LoginTitle=KIE Workbench
 # translation auto-copied from project KIE webapp distributions, version 6.0.0, document org.kie/kie-wb-webapp/org/kie/workbench/client/resources/i18n/LoginConstants, author nmirasch
 loginFailed=La connexion a \u00e9chou\u00e9 \: non autoris\u00e9
 # translation auto-copied from project KIE webapp distributions, version 6.0.0, document org.kie/kie-wb-webapp/org/kie/workbench/client/resources/i18n/LoginConstants, author nmirasch
-loginAsAnotherUser=Connectez-vous en tant qu''un autre utilisateur
+loginAsAnotherUser=Connectez-vous en tant qu'un autre utilisateur
 # translation auto-copied from project KIE webapp distributions, version 6.2.0, document org.kie/kie-wb-webapp/org/kie/workbench/client/resources/i18n/LoginConstants, author croe@redhat.com
 logoutSuccssful=D\u00e9connexion r\u00e9ussie
 # translation auto-copied from project KIE webapp distributions, version 6.2.0, document org.kie/kie-wb-webapp/org/kie/workbench/client/resources/i18n/LoginConstants, author croe@redhat.com
 loginAgain=Connectez-vous \u00e0 nouveau
 loadingPleaseWait=Veuillez patienter
-loadingApplication=Chargement de l''application...
+loadingApplication=Chargement de l'application...


### PR DESCRIPTION
Manual fix for 6.5.x i18n issues.

Zanata needs FR locale translated. Zanata team advised.

I have confirmed fetching i18n from Zanata does not overwrite these changes (since Zanata has no translations for these FR files and hence are skipped by the Maven plugin). 