### PR TITLE
Stunner - fix wrong class for bpmn-project artifact. It must be provided as it's client side stuff.

### DIFF
--- a/kie-wb/kie-wb-webapp/pom.xml
+++ b/kie-wb/kie-wb-webapp/pom.xml
@@ -1786,6 +1786,7 @@
     <dependency>
       <groupId>org.kie.workbench.stunner</groupId>
       <artifactId>kie-wb-common-stunner-bpmn-project</artifactId>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Hey @jlindop , this reverts [this merged commit](https://github.com/droolsjbpm/kie-wb-distributions/pull/412), which brokes the different distribution runtimes. See comments. Could you please verify? Thanks!