### PR TITLE
kie-wb-tests: move distribution wars dependencies to test scope

### DIFF
--- a/kie-wb-tests/pom.xml
+++ b/kie-wb-tests/pom.xml
@@ -202,12 +202,14 @@
           <groupId>org.kie</groupId>
           <artifactId>kie-wb-distribution-wars</artifactId>
           <classifier>${deployable.classifier.wildfly10}</classifier>
+          <scope>test</scope>
           <type>war</type>
         </dependency>
         <dependency>
           <groupId>org.kie</groupId>
           <artifactId>kie-drools-wb-distribution-wars</artifactId>
           <classifier>${deployable.classifier.wildfly10}</classifier>
+          <scope>test</scope>
           <type>war</type>
         </dependency>
       </dependencies>


### PR DESCRIPTION
So they won't be propagated as transitive dependencies to any project using for example kie-wb-tests-rest artifact.

@jhrcek FYI should solve transitive dependencies issue with kie-wb-tests-rest