### PR TITLE
[6.5.x][RHBRMS-2709] use Hibernate 4 in WFLY10/EAP7 WARs

### DIFF
--- a/kie-drools-wb/kie-drools-wb-distribution-wars/src/main/assembly/component-kie-drools-wb-wildfly-10-eap-7-common.xml
+++ b/kie-drools-wb/kie-drools-wb-distribution-wars/src/main/assembly/component-kie-drools-wb-wildfly-10-eap-7-common.xml
@@ -20,8 +20,8 @@
           <exclude>WEB-INF/classes/application-roles.properties</exclude>
           <exclude>WEB-INF/classes/application-users.properties</exclude>
 
+          <exclude>WEB-INF/classes/META-INF/persistence.xml</exclude>
           <exclude>WEB-INF/jboss-deployment-structure.xml</exclude>
-
           <exclude>WEB-INF/classes/org/kie/workbench/backend/weblogic/</exclude>
           <!-- Exclude WFLY8 uf-security-integration (replaced below by WFLY10-compatible one) -->
           <exclude>WEB-INF/lib/uberfire-security-management-wildfly8*</exclude>
@@ -31,6 +31,13 @@
     </dependencySet>
     <dependencySet>
       <includes>
+        <!-- Transitive deps of Hibernate 4 -->
+        <include>antlr:antlr</include>
+        <!-- End of Hibernate 4 transitive deps -->
+        <include>org.hibernate:hibernate-entitymanager</include>
+        <include>org.hibernate:hibernate-core</include>
+        <include>org.hibernate.common:hibernate-commons-annotations</include>
+
         <include>org.uberfire:uberfire-security-management-wildfly10</include>
       </includes>
       <outputDirectory>WEB-INF/lib</outputDirectory>

--- a/kie-drools-wb/kie-drools-wb-distribution-wars/src/main/assembly/wildfly10-eap7/WEB-INF/classes/META-INF/persistence.xml
+++ b/kie-drools-wb/kie-drools-wb-distribution-wars/src/main/assembly/wildfly10-eap7/WEB-INF/classes/META-INF/persistence.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+~ Copyright 2016 Red Hat, Inc. and/or its affiliates.
+~
+~ Licensed under the Apache License, Version 2.0 (the "License");
+~ you may not use this file except in compliance with the License.
+~ You may obtain a copy of the License at
+~
+~       http://www.apache.org/licenses/LICENSE-2.0
+~
+~ Unless required by applicable law or agreed to in writing, software
+~ distributed under the License is distributed on an "AS IS" BASIS,
+~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+~ See the License for the specific language governing permissions and
+~ limitations under the License.
+-->
+
+<persistence version="2.0"
+             xmlns="http://java.sun.com/xml/ns/persistence" xmlns:orm="http://java.sun.com/xml/ns/persistence/orm"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd
+                      http://java.sun.com/xml/ns/persistence/orm http://java.sun.com/xml/ns/persistence/orm_2_0.xsd">
+
+  <persistence-unit name="org.jbpm.domain" transaction-type="JTA">
+    <provider>org.hibernate.ejb.HibernatePersistence</provider>
+    <jta-data-source>java:jboss/datasources/ExampleDS</jta-data-source>
+    <mapping-file>META-INF/Taskorm.xml</mapping-file>
+    <mapping-file>META-INF/JBPMorm.xml</mapping-file>
+    <mapping-file>META-INF/Executor-orm.xml</mapping-file>
+    <mapping-file>META-INF/Servicesorm.xml</mapping-file>
+    <mapping-file>META-INF/TaskAuditorm.xml</mapping-file>
+
+    <!-- task service -->
+    <class>org.jbpm.services.task.impl.model.AttachmentImpl</class>
+    <class>org.jbpm.services.task.impl.model.ContentImpl</class>
+    <class>org.jbpm.services.task.impl.model.BooleanExpressionImpl</class>
+    <class>org.jbpm.services.task.impl.model.CommentImpl</class>
+    <class>org.jbpm.services.task.impl.model.DeadlineImpl</class>
+    <class>org.jbpm.services.task.impl.model.CommentImpl</class>
+    <class>org.jbpm.services.task.impl.model.DeadlineImpl</class>
+    <class>org.jbpm.services.task.impl.model.DelegationImpl</class>
+    <class>org.jbpm.services.task.impl.model.EscalationImpl</class>
+    <class>org.jbpm.services.task.impl.model.GroupImpl</class>
+    <class>org.jbpm.services.task.impl.model.I18NTextImpl</class>
+    <class>org.jbpm.services.task.impl.model.NotificationImpl</class>
+    <class>org.jbpm.services.task.impl.model.EmailNotificationImpl</class>
+    <class>org.jbpm.services.task.impl.model.EmailNotificationHeaderImpl</class>
+    <class>org.jbpm.services.task.impl.model.PeopleAssignmentsImpl</class>
+    <class>org.jbpm.services.task.impl.model.ReassignmentImpl</class>
+    <class>org.jbpm.services.task.impl.model.TaskImpl</class>
+    <class>org.jbpm.services.task.impl.model.TaskDefImpl</class>
+    <class>org.jbpm.services.task.impl.model.TaskDataImpl</class>
+    <class>org.jbpm.services.task.impl.model.UserImpl</class>
+    <class>org.jbpm.executor.entities.ErrorInfo</class>
+    <class>org.jbpm.executor.entities.RequestInfo</class>
+    <!-- Event Classes -->
+    <class>org.jbpm.services.task.audit.impl.model.TaskEventImpl</class>
+
+    <!-- Task Audit Classes -->
+    <class>org.jbpm.services.task.audit.impl.model.AuditTaskImpl</class>
+    <class>org.jbpm.services.task.audit.impl.model.TaskVariableImpl</class>
+
+    <!--BAM for task service -->
+    <class>org.jbpm.services.task.audit.impl.model.BAMTaskSummaryImpl</class>
+
+    <!-- engine -->
+    <class>org.drools.persistence.info.SessionInfo</class>
+    <class>org.jbpm.persistence.processinstance.ProcessInstanceInfo</class>
+    <class>org.drools.persistence.info.WorkItemInfo</class>
+    <class>org.jbpm.persistence.correlation.CorrelationKeyInfo</class>
+    <class>org.jbpm.persistence.correlation.CorrelationPropertyInfo</class>
+    <!-- manager -->
+    <class>org.jbpm.runtime.manager.impl.jpa.ContextMappingInfo</class>
+
+    <!-- bam -->
+    <class>org.jbpm.process.audit.ProcessInstanceLog</class>
+    <class>org.jbpm.process.audit.NodeInstanceLog</class>
+    <class>org.jbpm.process.audit.VariableInstanceLog</class>
+
+    <!-- deployment store -->
+    <class>org.jbpm.kie.services.impl.store.DeploymentStoreEntry</class>
+    <!-- query service storage -->
+    <class>org.jbpm.kie.services.impl.query.persistence.QueryDefinitionEntity</class>
+
+    <properties>
+      <property name="hibernate.dialect" value="org.hibernate.dialect.H2Dialect" />
+
+      <property name="hibernate.max_fetch_depth" value="3" />
+      <property name="hibernate.hbm2ddl.auto" value="update" />
+      <property name="hibernate.show_sql" value="false" />
+
+      <!-- BZ 841786: AS7/EAP 6/Hib 4 uses new (sequence) generators which seem to cause problems -->
+      <property name="hibernate.id.new_generator_mappings" value="false" />
+      <property name="hibernate.transaction.jta.platform" value="org.hibernate.service.jta.platform.internal.JBossAppServerJtaPlatform" />
+
+      <property name="jboss.as.jpa.providerModule" value="application" />
+    </properties>
+  </persistence-unit>
+
+</persistence>

--- a/kie-drools-wb/kie-drools-wb-distribution-wars/src/main/assembly/wildfly10-eap7/WEB-INF/jboss-deployment-structure.xml
+++ b/kie-drools-wb/kie-drools-wb-distribution-wars/src/main/assembly/wildfly10-eap7/WEB-INF/jboss-deployment-structure.xml
@@ -19,6 +19,11 @@
   -->
 <jboss-deployment-structure xmlns="urn:jboss:deployment-structure:1.1">
   <deployment>
+    <exclusions>
+      <!-- Hibernate 4 is bundled in the WAR, so the default Hibernate 5 needs to be excluded (disabled) -->
+      <module name="org.hibernate" slot="main"/>
+      <module name="org.hibernate.commons-annotations" slot="main"/>
+    </exclusions>
     <dependencies>
       <!-- IMPORTANT: when adding dependency (module) here, make sure it is a public one.
            Do not add private modules as there is no guarantee they won't be changed or
@@ -37,8 +42,6 @@
       <module name="org.apache.cxf"/>
       <module name="org.apache.xalan"/>
       <module name="org.apache.xerces"/>
-      <module name="org.hibernate"/>
-      <module name="org.hibernate.commons-annotations"/>
       <module name="org.hibernate.validator"/>
       <module name="org.jboss.ejb-client"/>
       <module name="org.jboss.logging"/>

--- a/kie-wb-smoke-tests/kie-wb-smoke-tests-main/src/main/java/org/kie/smoke/wb/util/handler/AbstractResponseHandler.java
+++ b/kie-wb-smoke-tests/kie-wb-smoke-tests-main/src/main/java/org/kie/smoke/wb/util/handler/AbstractResponseHandler.java
@@ -94,7 +94,7 @@ public abstract class AbstractResponseHandler<T,P> implements ResponseHandler<T>
       
         if( status != responseStatus ) { 
             if( ! myContentType.equals(contentType) ) { 
-                if( contentType.toString().contains("text/html") ) { 
+                if( contentType.toString().contains("text/html") || contentType.toString().contains("text/plain") ) {
                     StringWriter writer = new StringWriter();
                     char[] buffer = new char[1024];
                     for (int n; (n = reader.read(buffer)) != -1; ) {
@@ -105,7 +105,7 @@ public abstract class AbstractResponseHandler<T,P> implements ResponseHandler<T>
                     Document doc = Jsoup.parse(content);
                     String errorBody = doc.body().text();
                     fail( responseStatus + ": " + errorBody + " [expected " + status + "]" );
-                }  else { 
+                }  else {
                     assertEquals("Response status [content type: " + contentType.toString() + "]", status, responseStatus);
                 }
             } else if( contentType.toString().contains("text/plain") ) { 

--- a/kie-wb/kie-wb-distribution-wars/src/main/assembly/component-kie-wb-wildfly-10-eap-7-common.xml
+++ b/kie-wb/kie-wb-distribution-wars/src/main/assembly/component-kie-wb-wildfly-10-eap-7-common.xml
@@ -19,6 +19,7 @@
           <exclude>WEB-INF/classes/application-roles.properties</exclude>
           <exclude>WEB-INF/classes/application-users.properties</exclude>
 
+          <exclude>WEB-INF/classes/META-INF/persistence.xml</exclude>
           <exclude>WEB-INF/bpms-jms.xml</exclude>
           <exclude>WEB-INF/jboss-deployment-structure.xml</exclude>
           <exclude>WEB-INF/classes/org/kie/workbench/backend/weblogic/</exclude>
@@ -30,6 +31,13 @@
     </dependencySet>
     <dependencySet>
       <includes>
+        <!-- Transitive deps of Hibernate 4 -->
+        <include>antlr:antlr</include>
+        <!-- End of Hibernate 4 transitive deps -->
+        <include>org.hibernate:hibernate-entitymanager</include>
+        <include>org.hibernate:hibernate-core</include>
+        <include>org.hibernate.common:hibernate-commons-annotations</include>
+
         <include>org.uberfire:uberfire-security-management-wildfly10</include>
       </includes>
       <outputDirectory>WEB-INF/lib</outputDirectory>

--- a/kie-wb/kie-wb-distribution-wars/src/main/assembly/wildfly10-eap7/WEB-INF/classes/META-INF/persistence.xml
+++ b/kie-wb/kie-wb-distribution-wars/src/main/assembly/wildfly10-eap7/WEB-INF/classes/META-INF/persistence.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+~ Copyright 2016 Red Hat, Inc. and/or its affiliates.
+~
+~ Licensed under the Apache License, Version 2.0 (the "License");
+~ you may not use this file except in compliance with the License.
+~ You may obtain a copy of the License at
+~
+~       http://www.apache.org/licenses/LICENSE-2.0
+~
+~ Unless required by applicable law or agreed to in writing, software
+~ distributed under the License is distributed on an "AS IS" BASIS,
+~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+~ See the License for the specific language governing permissions and
+~ limitations under the License.
+-->
+
+<persistence version="2.0"
+             xmlns="http://java.sun.com/xml/ns/persistence" xmlns:orm="http://java.sun.com/xml/ns/persistence/orm"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd
+                      http://java.sun.com/xml/ns/persistence/orm http://java.sun.com/xml/ns/persistence/orm_2_0.xsd">
+
+  <persistence-unit name="org.jbpm.domain" transaction-type="JTA">
+    <provider>org.hibernate.ejb.HibernatePersistence</provider>
+    <jta-data-source>java:jboss/datasources/ExampleDS</jta-data-source>
+    <mapping-file>META-INF/Taskorm.xml</mapping-file>
+    <mapping-file>META-INF/JBPMorm.xml</mapping-file>
+    <mapping-file>META-INF/Executor-orm.xml</mapping-file>
+    <mapping-file>META-INF/Servicesorm.xml</mapping-file>
+    <mapping-file>META-INF/TaskAuditorm.xml</mapping-file>
+
+    <!-- task service -->
+    <class>org.jbpm.services.task.impl.model.AttachmentImpl</class>
+    <class>org.jbpm.services.task.impl.model.ContentImpl</class>
+    <class>org.jbpm.services.task.impl.model.BooleanExpressionImpl</class>
+    <class>org.jbpm.services.task.impl.model.CommentImpl</class>
+    <class>org.jbpm.services.task.impl.model.DeadlineImpl</class>
+    <class>org.jbpm.services.task.impl.model.CommentImpl</class>
+    <class>org.jbpm.services.task.impl.model.DeadlineImpl</class>
+    <class>org.jbpm.services.task.impl.model.DelegationImpl</class>
+    <class>org.jbpm.services.task.impl.model.EscalationImpl</class>
+    <class>org.jbpm.services.task.impl.model.GroupImpl</class>
+    <class>org.jbpm.services.task.impl.model.I18NTextImpl</class>
+    <class>org.jbpm.services.task.impl.model.NotificationImpl</class>
+    <class>org.jbpm.services.task.impl.model.EmailNotificationImpl</class>
+    <class>org.jbpm.services.task.impl.model.EmailNotificationHeaderImpl</class>
+    <class>org.jbpm.services.task.impl.model.PeopleAssignmentsImpl</class>
+    <class>org.jbpm.services.task.impl.model.ReassignmentImpl</class>
+    <class>org.jbpm.services.task.impl.model.TaskImpl</class>
+    <class>org.jbpm.services.task.impl.model.TaskDefImpl</class>
+    <class>org.jbpm.services.task.impl.model.TaskDataImpl</class>
+    <class>org.jbpm.services.task.impl.model.UserImpl</class>
+    <class>org.jbpm.executor.entities.ErrorInfo</class>
+    <class>org.jbpm.executor.entities.RequestInfo</class>
+    <!-- Event Classes -->
+    <class>org.jbpm.services.task.audit.impl.model.TaskEventImpl</class>
+
+    <!-- Task Audit Classes -->
+    <class>org.jbpm.services.task.audit.impl.model.AuditTaskImpl</class>
+    <class>org.jbpm.services.task.audit.impl.model.TaskVariableImpl</class>
+
+    <!--BAM for task service -->
+    <class>org.jbpm.services.task.audit.impl.model.BAMTaskSummaryImpl</class>
+
+    <!-- engine -->
+    <class>org.drools.persistence.info.SessionInfo</class>
+    <class>org.jbpm.persistence.processinstance.ProcessInstanceInfo</class>
+    <class>org.drools.persistence.info.WorkItemInfo</class>
+    <class>org.jbpm.persistence.correlation.CorrelationKeyInfo</class>
+    <class>org.jbpm.persistence.correlation.CorrelationPropertyInfo</class>
+    <!-- manager -->
+    <class>org.jbpm.runtime.manager.impl.jpa.ContextMappingInfo</class>
+
+    <!-- bam -->
+    <class>org.jbpm.process.audit.ProcessInstanceLog</class>
+    <class>org.jbpm.process.audit.NodeInstanceLog</class>
+    <class>org.jbpm.process.audit.VariableInstanceLog</class>
+
+    <!-- deployment store -->
+    <class>org.jbpm.kie.services.impl.store.DeploymentStoreEntry</class>
+    <!-- query service storage -->
+    <class>org.jbpm.kie.services.impl.query.persistence.QueryDefinitionEntity</class>
+
+    <properties>
+      <property name="hibernate.dialect" value="org.hibernate.dialect.H2Dialect" />
+
+      <property name="hibernate.max_fetch_depth" value="3" />
+      <property name="hibernate.hbm2ddl.auto" value="update" />
+      <property name="hibernate.show_sql" value="false" />
+
+      <!-- BZ 841786: AS7/EAP 6/Hib 4 uses new (sequence) generators which seem to cause problems -->
+      <property name="hibernate.id.new_generator_mappings" value="false" />
+      <property name="hibernate.transaction.jta.platform" value="org.hibernate.service.jta.platform.internal.JBossAppServerJtaPlatform" />
+
+      <property name="jboss.as.jpa.providerModule" value="application" />
+    </properties>
+  </persistence-unit>
+
+</persistence>

--- a/kie-wb/kie-wb-distribution-wars/src/main/assembly/wildfly10-eap7/WEB-INF/jboss-deployment-structure.xml
+++ b/kie-wb/kie-wb-distribution-wars/src/main/assembly/wildfly10-eap7/WEB-INF/jboss-deployment-structure.xml
@@ -17,8 +17,13 @@
   ~ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
   ~ MA  02110-1301, USA.
   -->
-<jboss-deployment-structure xmlns="urn:jboss:deployment-structure:1.1">
+<jboss-deployment-structure xmlns="urn:jboss:deployment-structure:1.2">
   <deployment>
+    <exclusions>
+      <!-- Hibernate 4 is bundled in the WAR, so the default Hibernate 5 needs to be excluded (disabled) -->
+      <module name="org.hibernate" slot="main"/>
+      <module name="org.hibernate.commons-annotations" slot="main"/>
+    </exclusions>
     <dependencies>
       <!-- IMPORTANT: when adding dependency (module) here, make sure it is a public one.
            Do not add private modules as there is no guarantee they won't be changed or
@@ -37,8 +42,6 @@
       <module name="org.apache.xalan"/>
       <module name="org.apache.xerces"/>
       <module name="org.apache.cxf"/>
-      <module name="org.hibernate"/>
-      <module name="org.hibernate.commons-annotations"/>
       <module name="org.hibernate.validator"/>
       <module name="org.jboss.ejb-client"/>
       <module name="org.jboss.logging"/>


### PR DESCRIPTION
Upgrading just core Hibernate libraries which seems safe.
Hibernate Validator was not updated as it causes compatibility
issues with javax.validation, Weld and RestEasy.