### PR TITLE
Tomcat needs specific listener order to avoid UF shutdown issues

### DIFF
--- a/kie-drools-wb/kie-drools-wb-distribution-wars/src/main/assembly/tomcat8/WEB-INF/web.xml
+++ b/kie-drools-wb/kie-drools-wb-distribution-wars/src/main/assembly/tomcat8/WEB-INF/web.xml
@@ -4,13 +4,18 @@
          xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd">
 
   <distributable/>
-  <listener>
-    <listener-class>org.uberfire.backend.server.io.DisposableShutdownService</listener-class>
-  </listener>
 
   <listener>
     <listener-class>org.jboss.weld.environment.servlet.Listener</listener-class>
   </listener>
+
+  <listener>
+    <!-- Important: order of the listeners matters! The DisposableShutdownService needs to be specified
+                    _after_ the Weld servlet listener. Otherwise the disposable service will fail as
+                    "systemFS" will be closed by the Weld listener.-->
+    <listener-class>org.uberfire.backend.server.io.DisposableShutdownService</listener-class>
+  </listener>
+
   <listener>
     <listener-class>org.jboss.resteasy.plugins.server.servlet.ResteasyBootstrap</listener-class>
   </listener>

--- a/kie-wb/kie-wb-distribution-wars/src/main/assembly/tomcat8/WEB-INF/web.xml
+++ b/kie-wb/kie-wb-distribution-wars/src/main/assembly/tomcat8/WEB-INF/web.xml
@@ -5,12 +5,16 @@
 
   <distributable/>
   <listener>
-    <listener-class>org.uberfire.backend.server.io.DisposableShutdownService</listener-class>
+    <listener-class>org.jboss.weld.environment.servlet.Listener</listener-class>
   </listener>
 
   <listener>
-    <listener-class>org.jboss.weld.environment.servlet.Listener</listener-class>
+    <!-- Important: order of the listeners matters! The DisposableShutdownService needs to be specified
+                    _after_ the Weld servlet listener. Otherwise the disposable service will fail as
+                    "systemFS" will be closed by the Weld listener.-->
+    <listener-class>org.uberfire.backend.server.io.DisposableShutdownService</listener-class>
   </listener>
+
   <listener>
     <listener-class>org.jboss.resteasy.plugins.server.servlet.ResteasyBootstrap</listener-class>
   </listener>


### PR DESCRIPTION
cc @ederign it indeed seems the order of the execution somehow changed. But I am not exactly sure when that happened, since the Tomcat WARs were broken for ages even before this issue.

There is still one thing I don't understand. The UF clean-up happens basically twice - once directly via the Weld destroy() method and the second time using the DisposableShutdownService. This is something worth taking a look at I think. Ideally the clean-up should happen just once.