### PR TITLE
JBPM-5731: Stunner - Diagram related dock screens only appear on the authoring perspective.

### DIFF
--- a/kie-drools-wb-parent/kie-drools-wb-webapp/src/main/java/org/kie/workbench/drools/client/perspectives/DroolsAuthoringNoContextNavigationPerspective.java
+++ b/kie-drools-wb-parent/kie-drools-wb-webapp/src/main/java/org/kie/workbench/drools/client/perspectives/DroolsAuthoringNoContextNavigationPerspective.java
@@ -25,9 +25,7 @@ import javax.inject.Inject;
 import com.google.gwt.user.client.Window;
 import org.jboss.errai.common.client.api.Caller;
 import org.jboss.errai.common.client.api.RemoteCallback;
-import org.kie.workbench.common.stunner.project.client.screens.ProjectDiagramWorkbenchDocks;
 import org.kie.workbench.common.widgets.client.handlers.NewResourcesMenu;
-import org.kie.workbench.common.workbench.client.PerspectiveIds;
 import org.kie.workbench.common.workbench.client.docks.AuthoringWorkbenchDocks;
 import org.kie.workbench.drools.client.resources.i18n.AppConstants;
 import org.uberfire.backend.vfs.Path;
@@ -69,9 +67,6 @@ public class DroolsAuthoringNoContextNavigationPerspective {
     @Inject
     private AuthoringWorkbenchDocks docks;
 
-    @Inject
-    private ProjectDiagramWorkbenchDocks stunnerWorkbenchEditorDocks;
-
     private String explorerMode;
     private String projectPathString;
     private boolean projectEditorDisableBuild;
@@ -87,7 +82,6 @@ public class DroolsAuthoringNoContextNavigationPerspective {
         final PlaceRequest placeRequest = generateProjectExplorerPlaceRequest();
 
         docks.setup("AuthoringPerspectiveNoContext", placeRequest);
-        stunnerWorkbenchEditorDocks.setup( "AuthoringPerspectiveNoContext" );
 
     }
 

--- a/kie-drools-wb-parent/kie-drools-wb-webapp/src/main/java/org/kie/workbench/drools/client/perspectives/DroolsAuthoringPerspective.java
+++ b/kie-drools-wb-parent/kie-drools-wb-webapp/src/main/java/org/kie/workbench/drools/client/perspectives/DroolsAuthoringPerspective.java
@@ -19,7 +19,6 @@ import org.kie.workbench.common.screens.examples.client.wizard.ExamplesWizard;
 import org.kie.workbench.common.screens.examples.service.ExamplesService;
 import org.kie.workbench.common.screens.library.api.LibraryContextSwitchEvent;
 import org.kie.workbench.common.services.shared.preferences.ApplicationPreferences;
-import org.kie.workbench.common.stunner.project.client.screens.ProjectDiagramWorkbenchDocks;
 import org.kie.workbench.common.widgets.client.handlers.NewResourcePresenter;
 import org.kie.workbench.common.widgets.client.handlers.NewResourcesMenu;
 import org.kie.workbench.common.widgets.client.menu.RepositoryMenu;
@@ -69,15 +68,11 @@ public class DroolsAuthoringPerspective {
     private AuthoringWorkbenchDocks docks;
 
     @Inject
-    private ProjectDiagramWorkbenchDocks stunnerWorkbenchEditorDocks;
-
-    @Inject
     private ExamplesWizard wizard;
 
     @PostConstruct
     public void setup() {
         docks.setup( PerspectiveIds.AUTHORING, new DefaultPlaceRequest( "org.kie.guvnor.explorer" ) );
-        stunnerWorkbenchEditorDocks.setup( PerspectiveIds.AUTHORING );
     }
 
     @Perspective

--- a/kie-wb-parent/kie-wb-webapp/src/main/java/org/kie/workbench/client/perspectives/DroolsAuthoringNoContextNavigationPerspective.java
+++ b/kie-wb-parent/kie-wb-webapp/src/main/java/org/kie/workbench/client/perspectives/DroolsAuthoringNoContextNavigationPerspective.java
@@ -26,7 +26,6 @@ import com.google.gwt.user.client.Window;
 import org.jboss.errai.common.client.api.Caller;
 import org.jboss.errai.common.client.api.RemoteCallback;
 import org.kie.workbench.client.resources.i18n.AppConstants;
-import org.kie.workbench.common.stunner.project.client.screens.ProjectDiagramWorkbenchDocks;
 import org.kie.workbench.common.widgets.client.handlers.NewResourcesMenu;
 import org.kie.workbench.common.workbench.client.docks.AuthoringWorkbenchDocks;
 import org.uberfire.backend.vfs.Path;
@@ -68,9 +67,6 @@ public class DroolsAuthoringNoContextNavigationPerspective {
     @Inject
     private AuthoringWorkbenchDocks docks;
 
-    @Inject
-    private ProjectDiagramWorkbenchDocks stunnerWorkbenchEditorDocks;
-
     private String explorerMode;
     private String projectPathString;
     private boolean projectEditorDisableBuild;
@@ -86,7 +82,6 @@ public class DroolsAuthoringNoContextNavigationPerspective {
         final PlaceRequest placeRequest = generateProjectExplorerPlaceRequest();
 
         docks.setup("AuthoringPerspectiveNoContext", placeRequest);
-        stunnerWorkbenchEditorDocks.setup( "AuthoringPerspectiveNoContext" );
 
     }
 

--- a/kie-wb-parent/kie-wb-webapp/src/main/java/org/kie/workbench/client/perspectives/DroolsAuthoringPerspective.java
+++ b/kie-wb-parent/kie-wb-webapp/src/main/java/org/kie/workbench/client/perspectives/DroolsAuthoringPerspective.java
@@ -21,7 +21,6 @@ import org.kie.workbench.common.screens.examples.service.ExamplesService;
 import org.kie.workbench.common.screens.library.api.LibraryContextSwitchEvent;
 import org.kie.workbench.common.screens.projecteditor.client.menu.ProjectMenu;
 import org.kie.workbench.common.services.shared.preferences.ApplicationPreferences;
-import org.kie.workbench.common.stunner.project.client.screens.ProjectDiagramWorkbenchDocks;
 import org.kie.workbench.common.widgets.client.handlers.NewResourcePresenter;
 import org.kie.workbench.common.widgets.client.handlers.NewResourcesMenu;
 import org.kie.workbench.common.widgets.client.menu.RepositoryMenu;
@@ -70,15 +69,11 @@ public class DroolsAuthoringPerspective {
     private AuthoringWorkbenchDocks docks;
 
     @Inject
-    private ProjectDiagramWorkbenchDocks stunnerWorkbenchEditorDocks;
-
-    @Inject
     private ExamplesWizard wizard;
 
     @PostConstruct
     public void setup() {
         docks.setup( PerspectiveIds.AUTHORING, new DefaultPlaceRequest( "org.kie.guvnor.explorer" ) );
-        stunnerWorkbenchEditorDocks.setup( PerspectiveIds.AUTHORING );
     }
 
     @Perspective


### PR DESCRIPTION
Hey @manstis @mbarkley 
This is the fix for the workbench webapps. Just remove custom docks handler for Stunner and use the shared one.
Depends on https://github.com/droolsjbpm/kie-wb-common/pull/705
Thanks!